### PR TITLE
some modify:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influx_db_client"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["piaoliu <441594700@qq.com>"]
 documentation = "https://docs.rs/influx_db_client/"
 repository = "https://github.com/driftluo/InfluxDBClient-rs"

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ This is an InfluxDB driver for Rust.
 
 ## Status
 
-This project has been able to run properly,
-most of the problems still on the type of return value,
-I have no solution to this problem, PR are welcome.
+This project has been able to run properly, PR are welcome.
 
 ### Todo
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fn main() {
 
 This is the [API Document](https://docs.influxdata.com/influxdb/v1.2/tools/api/), it may apply to version 1.0 or higher.
 
-I have tested it in version 1.0.2.
+I have tested it in version 1.0.2 and 1.3.5.
 
 ## Thanks
 


### PR DESCRIPTION
1. BTreeMap -> HashMap, field and tags don't  need to be sorted
2. 'a str -> String, because it's so ugly
3. &str -> T, generics is so well
4. unsafe impl Send for InfluxdbClient, You can pass the client to the thread now