### PR TITLE
Add tags to Series structure

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -122,7 +122,9 @@ pub struct Node {
 pub struct Series {
     /// measurement
     pub name: String,
-    /// fields and tages name and time
+    /// tag
+    pub tags: Option<serde_json::Map<String, serde_json::Value>>,
+    /// field names and time
     pub columns: Vec<String>,
     /// values
     pub values: Vec<Vec<serde_json::Value>>


### PR DESCRIPTION
add tags to the series object, influx returns the tags as an object in the series object.
As of 1.4 tags should always contain String values however serde only provides Map<String, Value> as a derivable type. 
