### PR TITLE
Support chunked responses.

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -116,6 +116,9 @@ pub struct Query {
     pub error: Option<String>,
 }
 
+/// Chunked Query data
+pub type ChunkedQuery<'de, T> = serde_json::StreamDeserializer<'de, T, Query>;
+
 /// Query data node
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Node {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,5 +83,5 @@ pub mod client;
 pub mod keys;
 
 pub use client::{Client, TLSOption, UdpClient};
-pub use keys::{Node, Point, Points, Precision, Query, Series, Value};
+pub use keys::{Node, Point, Points, Precision, Query, ChunkedQuery, Series, Value};
 pub use error::Error;


### PR DESCRIPTION
This is my attempt to support chunked queries (see https://github.com/driftluo/InfluxDBClient-rs/issues/26).

There is a new method `query_chunked` which sends the request to influxdb with `chunked=true` and returns an iterator. This is great because we are streaming directly from the request and so, I gather, we never have to read the whole thing completely into memory if we do not want to.
