### PR TITLE
Use Into<String> Instead of ToString in API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -29,21 +29,21 @@ impl Client {
     /// Create a new influxdb client with http
     pub fn new<T>(host: T, db: T) -> Self
     where
-        T: ToString,
+        T: Into<String>,
     {
         Client {
-            host: host.to_string(),
-            db: db.to_string(),
+            host: host.into(),
+            db: db.into(),
             authentication: None,
             client: HttpClient::default(),
         }
     }
 
     /// Create a new influxdb client with https
-    pub fn new_with_option<T: ToString>(host: T, db: T, tls_option: Option<TLSOption>) -> Self {
+    pub fn new_with_option<T: Into<String>>(host: T, db: T, tls_option: Option<TLSOption>) -> Self {
         Client {
-            host: host.to_string(),
-            db: db.to_string(),
+            host: host.into(),
+            db: db.into(),
             authentication: None,
             client: HttpClient::new_with_option(tls_option),
         }
@@ -62,9 +62,9 @@ impl Client {
     /// Change the client's database
     pub fn switch_database<T>(&mut self, database: T)
     where
-        T: ToString,
+        T: Into<String>,
     {
-        self.db = database.to_string();
+        self.db = database.into();
     }
 
     /// Change the client's user

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -42,14 +42,14 @@ impl Point {
     }
 
     /// Add a tag and its value
-    pub fn add_tag<T: ToString>(&mut self, tag: T, value: Value) -> &mut Self {
-        self.tags.insert(tag.to_string(), value);
+    pub fn add_tag<T: Into<String>>(&mut self, tag: T, value: Value) -> &mut Self {
+        self.tags.insert(tag.into(), value);
         self
     }
 
     /// Add a field and its value
-    pub fn add_field<T: ToString>(&mut self, field: T, value: Value) -> &mut Self {
-        self.fields.insert(field.to_string(), value);
+    pub fn add_field<T: Into<String>>(&mut self, field: T, value: Value) -> &mut Self {
+        self.fields.insert(field.into(), value);
         self
     }
 


### PR DESCRIPTION
Previously the API used a mix of Into<String> and ToString. Into<String>
is better suited to pass in strings, since the ToString trait comes from
the Display trait which is for human readable representations of values.