### PR TITLE
Bump to 0.4.5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influx_db_client"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["piaoliu <441594700@qq.com>"]
 documentation = "https://docs.rs/influx_db_client/"
 repository = "https://github.com/driftluo/InfluxDBClient-rs"


### PR DESCRIPTION
Can you push a new version to crates.io?