### PR TITLE
Allow points to be passed by ownership or by ref

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use futures::prelude::*;
 use reqwest::{Client as HttpClient, Response, Url};
 use serde_json::de::IoRead;
 use std::{
+    borrow::Borrow,
     io::Cursor,
     iter::FromIterator,
     net::UdpSocket,
@@ -123,7 +124,7 @@ impl Client {
     }
 
     /// Write multiple points to the database
-    pub fn write_points<T: Iterator<Item = Point>>(
+    pub fn write_points<T: IntoIterator<Item = impl Borrow<Point>>>(
         &self,
         points: T,
         precision: Option<Precision>,
@@ -538,7 +539,7 @@ impl UdpClient {
 
         let line = serialization::line_serialization(points);
         let line = line.as_bytes();
-        socket.send_to(&line, self.hosts.as_slice())?;
+        socket.send_to(line, self.hosts.as_slice())?;
 
         Ok(())
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::iter::FromIterator;
-use std::iter::Iterator;
+use std::{
+    collections::HashMap,
+    iter::{FromIterator, Iterator},
+    slice::Iter,
+};
 
 /// Influxdb value, Please look at [this address](https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_reference/)
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
@@ -70,9 +72,7 @@ pub struct Points {
 impl Points {
     /// Create a new points
     pub fn new(point: Point) -> Points {
-        let mut points = Vec::new();
-        points.push(point);
-        Points { point: points }
+        Points { point: vec![point] }
     }
 
     /// Insert point into already existing points
@@ -84,6 +84,15 @@ impl Points {
     /// Create a multi Points more directly
     pub fn create_new(points: Vec<Point>) -> Points {
         Points { point: points }
+    }
+}
+
+impl<'a> IntoIterator for &'a Points {
+    type Item = &'a Point;
+    type IntoIter = Iter<'a, Point>;
+
+    fn into_iter(self) -> Iter<'a, Point> {
+        self.point.iter()
     }
 }
 


### PR DESCRIPTION
`write_points` expects an owned `Iterator` of `Point`. It would be more
convienient to allow the points to be passed by reference or by
ownership.

impl `IntoIterator` for `&Points` and update trait bounds on
`write_points` and a few others to `IntoIterator<Item = impl Borrow<Point>>`

This allows the user to pass either by ownership or by reference.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>