### PR TITLE
Use `Cow` in `Value` for String

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -113,18 +113,18 @@ impl Client {
     }
 
     /// Write a point to the database
-    pub fn write_point(
+    pub fn write_point<'a>(
         &self,
-        point: Point,
+        point: Point<'a>,
         precision: Option<Precision>,
         rp: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + 'a {
         let points = Points::new(point);
         self.write_points(points, precision, rp)
     }
 
     /// Write multiple points to the database
-    pub fn write_points<T: IntoIterator<Item = impl Borrow<Point>>>(
+    pub fn write_points<'a, T: IntoIterator<Item = impl Borrow<Point<'a>>>>(
         &self,
         points: T,
         precision: Option<Precision>,


### PR DESCRIPTION
When adding tags and field values, the `value` param is converted to a `String` if it's a `&str`.

We can optimize this case by internally switching  `Value::String` to contain a `Cow<'a, str>`.

In addition, update the `line_serialization` fn to push into a `mut String` rather than a `Vec`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>