### PR TITLE
Mirror `reqwest`'s feature structure for `rustls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ default = ["reqwest/default-tls"]
 
 # For using rustls-tls (and no need for openssl anymore)
 rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]


### PR DESCRIPTION
Adds additional `rustls-tls-` features that mirror the state of affairs in `reqwest`. 

The intention is to allow users to select the root certificates used in conjunction with `rustls` by forwarding the feature through `influx_db_client`.

As features are additive, there isn't really a good way to achieve this otherwise - one can add a direct dependency on `reqwest` with the desired feature, but `influx_db_client` will still enable `reqwest/rustls-tls`, which selects `reqwest/rustls-tls-webpki-roots` by default. 