### PR TITLE
Lifetime of new Point shouldn't be tied to lifetime of measurement

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -35,8 +35,8 @@ pub struct Point<'a> {
 
 impl<'a> Point<'a> {
     /// Create a new point
-    pub fn new(measurement: &str) -> Point {
-        Point {
+    pub fn new(measurement: &'_ str) -> Self {
+        Self {
             measurement: String::from(measurement),
             tags: HashMap::new(),
             fields: HashMap::new(),

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -33,6 +33,7 @@ fn create_and_delete_measurement() {
 
         tokio::spawn(client.write_point(point, Some(Precision::Seconds), None))
             .await
+            .unwrap()
             .unwrap();
 
         client.drop_measurement("temporary").await.unwrap();
@@ -62,6 +63,7 @@ fn use_points() {
 
         tokio::spawn(client.write_points(points, Some(Precision::Seconds), None))
             .await
+            .unwrap()
             .unwrap();
 
         sleep(Duration::from_secs(3));


### PR DESCRIPTION
The string slice is cloned, so there's no need to tie the lifetime of the new `Point` to it.