### PR TITLE
feat: generic client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: Github Action
 
 on:
-  pull_request:  # trigger on pull requests
+  pull_request: # trigger on pull requests
   push:
     branches:
-      - master    # trigger on push to master
+      - master # trigger on push to master
       - ci
 
 jobs:
@@ -22,5 +22,5 @@ jobs:
           wget https://dl.influxdata.com/influxdb/releases/influxdb_1.8.0_amd64.deb
           sudo dpkg -i influxdb_1.8.0_amd64.deb
           sudo /usr/bin/influxd > $HOME/influx.log 2>&1 &
-          cargo test
+          RUST_BACKTRACE=1 cargo test
           cat $HOME/influx.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influx_db_client"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["piaoliu <441594700@qq.com>"]
 documentation = "https://docs.rs/influx_db_client/"
 repository = "https://github.com/driftluo/InfluxDBClient-rs"
@@ -10,17 +10,22 @@ keywords = ["influxdb"]
 categories = ["database"]
 license = "MIT"
 include = ["Cargo.toml", "src/*.rs", "README.md", "LICENSE"]
-edition = "2018"
+edition = "2024"
+rust-version = "1.85"
 
 [badges]
 travis-ci = { repository = "driftluo/InfluxDBClient-rs" }
 
 [dependencies]
-reqwest = { version = "^0.12", default-features = false, features = ["json"] }
+reqwest = { version = "^0.13.2", optional = true, default-features = false, features = [
+    "json",
+    "stream",
+] }
 serde_json = '^1.0.2'
 serde = { version = "^1.0.15", features = ["derive"] }
 bytes = "^1"
 futures = "^0.3"
+url = "^2.5"
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -28,11 +33,11 @@ tokio = { version = "1", features = ["full"] }
 
 
 [features]
-default = ["reqwest/default-tls"]
+default = ["reqwest", "reqwest/default-tls"]
+reqwest = ["dep:reqwest"]
 
 
-# For using rustls-tls (and no need for openssl anymore)
-rustls-tls = ["reqwest/rustls-tls"]
-rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
-rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
-rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+# Explicit native-tls backend.
+native-tls = ["reqwest", "reqwest/native-tls"]
+native-tls-vendored = ["reqwest", "reqwest/native-tls-vendored"]
+native-tls-no-alpn = ["reqwest", "reqwest/native-tls-no-alpn"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fn main() {
     let points = points!(point1, point);
 
     tokio::runtime::Runtime::new().unwrap().block_on(async move {
-        // if Precision is None, the default is second
+        // if Precision is None, the default is nanosecond
         // Multiple write
         client.write_points(points, Some(Precision::Seconds), None).await.unwrap();
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,14 @@ This project has been able to run properly, PR is welcome.
 
 ```
 [dependencies]
-influx_db_client = "^0.5.0"
+influx_db_client = "^0.7.0"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 ```
 
 ### http
 
-```Rust
-use influx_db_client::{
-    Client, Point, Points, Value, Precision, point, points
-};
-use tokio;
+```rust,no_run
+use influx_db_client::{Client, Point, Points, Precision, point, points};
 
 fn main() {
     // default with "http://127.0.0.1:8086", db with "test"
@@ -62,16 +60,69 @@ fn main() {
 }
 ```
 
+`Client` defaults to `reqwest::Client` when the default `reqwest` feature is enabled,
+but it is generic over the HTTP implementation.
+If you need a custom transport, implement `HttpClient` and `HttpResponse`, then create it with
+`Client::new_with_client(...)`.
+Borrowing query APIs such as `query_borrow`, `query_chunked_borrow`, and the corresponding
+query-backed `*_borrow` management APIs only require those base traits.
+Owned query APIs such as `query`, `query_chunked`, and the query-backed management commands require
+`QueryHttpClient` and `QueryHttpResponse`. Owned chunked queries also require
+`QueryChunkedHttpResponse`.
+If the transport also needs to support write APIs, implement `WriteHttpClient` and
+`WriteHttpResponse` as well. Chunked responses now expose an async byte stream rather than a
+blocking reader.
+
+`query_chunked` is an incompatible API change in this release: it now returns an async stream
+instead of a synchronous iterator. Add `futures = "0.3"` if you want to consume it with
+`StreamExt::next`:
+
+```rust,no_run
+use futures::StreamExt;
+use influx_db_client::{Client, Query};
+
+# #[cfg(feature = "reqwest")] {
+# tokio::runtime::Runtime::new().unwrap().block_on(async move {
+let client = Client::default();
+let mut stream = client.query_chunked("select * from test1", None).await.unwrap();
+
+while let Some(result) = stream.next().await {
+    let query: Query = result.unwrap();
+    println!("{:?}", query.results);
+}
+# });
+# }
+```
+
+To avoid compiling `reqwest`, disable default features and provide your own HTTP client:
+
+```toml
+[dependencies]
+influx_db_client = { version = "^0.7.0", default-features = false }
+```
+
+The crate's default `reqwest/default-tls` path currently resolves to a rustls-based backend.
+This is an incompatible feature-name update: the previous `rustls-tls*` feature names were removed.
+
+To build the default `reqwest` transport with the `native-tls` backend, disable default features
+and enable one of the `native-tls*` features explicitly. On Linux that typically means OpenSSL;
+on macOS and Windows it uses the platform TLS stack:
+
+```toml
+[dependencies]
+influx_db_client = { version = "^0.7.0", default-features = false, features = ["native-tls"] }
+```
+
 ### udp
 
-```Rust
-use influx_db_client::{UdpClient, Point, Value, point};
+```rust,no_run
+use influx_db_client::{Point, UdpClient, point};
 
 fn main() {
-    let mut udp = UdpClient::new("127.0.0.1:8089");
-    udp.add_host("127.0.0.1:8090");
+    let mut udp = UdpClient::new("127.0.0.1:8089".parse().unwrap());
+    udp.add_host("127.0.0.1:8090".parse().unwrap());
 
-    let point = point!("test").add_field("foo", Value::String(String::from("bar")));
+    let point = point!("test").add_field("foo", "bar");
 
     udp.write_point(point).unwrap();
 }

--- a/README.md
+++ b/README.md
@@ -62,15 +62,18 @@ fn main() {
 
 `Client` defaults to `reqwest::Client` when the default `reqwest` feature is enabled,
 but it is generic over the HTTP implementation.
-If you need a custom transport, implement `HttpClient` and `HttpResponse`, then create it with
-`Client::new_with_client(...)`.
-Borrowing query APIs such as `query_borrow`, `query_chunked_borrow`, and the corresponding
-query-backed `*_borrow` management APIs only require those base traits.
-Owned query APIs such as `query`, `query_chunked`, and the query-backed management commands require
-`QueryHttpClient` and `QueryHttpResponse`. Owned chunked queries also require
-`QueryChunkedHttpResponse`.
-If the transport also needs to support write APIs, implement `WriteHttpClient` and
-`WriteHttpResponse` as well. Chunked responses now expose an async byte stream rather than a
+If you need a custom transport, implement the transport traits for the APIs you want to support,
+then create it with `Client::new_with_client(...)`.
+Borrowing APIs such as `ping_borrow`, `get_version_borrow`, `query_borrow`,
+`query_chunked_borrow`, `write_point_borrow`, `write_points_borrow`, and the corresponding
+query-backed `*_borrow` management APIs require `BorrowHttpClient` and `BorrowHttpResponse`.
+Borrowed chunked queries also require `BorrowChunkedHttpResponse`. Spawn-safe APIs such as `ping`,
+`get_version`, `query`, `query_chunked`, `write_point`, `write_points`, and the query-backed
+management commands require `HttpClient` and `HttpResponse`. Spawn-safe chunked queries also
+require `ChunkedHttpResponse`. You can implement borrowed-only, spawn-safe-only, or both modes on the same
+transport type.
+Borrowing APIs use borrowed `HttpRequest` data, while spawnable query/write APIs receive owned
+`HttpRequest<'static>` values. Chunked responses now expose an async byte stream rather than a
 blocking reader.
 
 `query_chunked` is an incompatible API change in this release: it now returns an async stream

--- a/src/client.rs
+++ b/src/client.rs
@@ -424,7 +424,7 @@ where
 
         match precision {
             Some(ref t) => param.push(("precision", t.to_str())),
-            None => param.push(("precision", "s")),
+            None => param.push(("precision", Precision::Nanoseconds.to_str())),
         };
 
         if let Some(t) = rp {
@@ -2312,6 +2312,26 @@ mod tests {
         assert_eq!(requests[0].body.as_deref(), Some("cpu value=1i 42\n"));
         assert!(requests[0].url.contains("/write"));
         assert!(requests[0].url.contains("precision=s"));
+    }
+
+    #[test]
+    fn custom_http_client_write_points_default_to_nanosecond_precision() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse::empty(204)]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        );
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        block_on(client.write_point(point, None, None)).unwrap();
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].body.as_deref(), Some("cpu value=1i 42\n"));
+        assert!(requests[0].url.contains("/write"));
+        assert!(requests[0].url.contains("precision=n"));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,29 +1,230 @@
+#[cfg(feature = "reqwest")]
 use bytes::Bytes;
 use futures::prelude::*;
-use reqwest::{Client as HttpClient, Response, Url};
-use serde_json::de::IoRead;
+#[cfg(feature = "reqwest")]
+use serde::de::DeserializeOwned;
 use std::{
     borrow::Borrow,
-    io::Cursor,
+    future::Future,
     iter::FromIterator,
     net::UdpSocket,
     net::{SocketAddr, ToSocketAddrs},
 };
+use url::Url;
 
-use crate::{error, serialization, ChunkedQuery, Node, Point, Points, Precision, Query};
+#[cfg(feature = "reqwest")]
+use reqwest::{Client as ReqwestClient, Response as ReqwestResponse};
+
+use crate::{
+    ChunkedQuery, Node, Point, Points, Precision, Query, error,
+    http::{
+        ChunkedHttpResponse, HttpClient, HttpRequest, HttpResponse, QueryChunkedHttpResponse,
+        QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+    },
+    keys::{ensure_query_success, query_syntax_error},
+    serialization,
+};
+
+#[cfg(feature = "reqwest")]
+impl HttpResponse for ReqwestResponse {
+    fn status(&self) -> u16 {
+        self.status().as_u16()
+    }
+
+    fn header(&self, name: &str) -> Result<Option<&str>, error::Error> {
+        match self.headers().get(name) {
+            Some(value) => value
+                .to_str()
+                .map(Some)
+                .map_err(|err| error::Error::Communication(err.to_string())),
+            None => Ok(None),
+        }
+    }
+
+    async fn text(self) -> Result<String, error::Error> {
+        Ok(reqwest::Response::text(self).await?)
+    }
+
+    async fn bytes(self) -> Result<Bytes, error::Error> {
+        Ok(reqwest::Response::bytes(self).await?)
+    }
+
+    async fn json<T>(self) -> Result<T, error::Error>
+    where
+        T: DeserializeOwned,
+    {
+        Ok(reqwest::Response::json(self).await?)
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl QueryHttpResponse for ReqwestResponse {
+    async fn json_send<T>(self) -> Result<T, error::Error>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        Ok(reqwest::Response::json(self).await?)
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl ChunkedHttpResponse for ReqwestResponse {
+    type Stream =
+        std::pin::Pin<Box<dyn Stream<Item = Result<Bytes, error::Error>> + Send + 'static>>;
+
+    async fn into_chunk_stream(self) -> Result<Self::Stream, error::Error> {
+        Ok(Box::pin(
+            reqwest::Response::bytes_stream(self).map_err(Into::into),
+        ))
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl QueryChunkedHttpResponse for ReqwestResponse {
+    async fn into_chunk_stream_send(self) -> Result<Self::Stream, error::Error> {
+        Ok(Box::pin(
+            reqwest::Response::bytes_stream(self).map_err(Into::into),
+        ))
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl WriteHttpClient for ReqwestClient {
+    fn post_send(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<(u16, String), error::Error>> + Send + 'static + use<> {
+        let (url, body, bearer_token) = request.into_parts();
+        let builder = self.post(url);
+        let builder = if let Some(token) = bearer_token {
+            builder.bearer_auth(token)
+        } else {
+            builder
+        };
+        let builder = if let Some(body) = body {
+            builder.body(body)
+        } else {
+            builder
+        };
+
+        async move {
+            let res = builder.send().await?;
+            let status = res.status().as_u16();
+            let body = reqwest::Response::text(res).await?;
+            Ok((status, body))
+        }
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl HttpClient for ReqwestClient {
+    type Response = ReqwestResponse;
+
+    fn get(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+        let (url, _body, bearer_token) = request.into_parts();
+        let builder = if let Some(token) = bearer_token {
+            self.get(url).bearer_auth(token)
+        } else {
+            self.get(url)
+        };
+
+        async move { Ok(builder.send().await?) }
+    }
+
+    fn post(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'_> {
+        let (url, body, bearer_token) = request.into_parts();
+        let builder = self.post(url);
+        let builder = if let Some(token) = bearer_token {
+            builder.bearer_auth(token)
+        } else {
+            builder
+        };
+        let builder = if let Some(body) = body {
+            builder.body(body)
+        } else {
+            builder
+        };
+
+        async move { Ok(builder.send().await?) }
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl QueryHttpClient for ReqwestClient {
+    fn send_get(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+        let client = self.clone();
+        let (url, _body, bearer_token) = request.into_parts();
+
+        async move {
+            let builder = if let Some(token) = bearer_token {
+                client.get(url).bearer_auth(token)
+            } else {
+                client.get(url)
+            };
+
+            Ok(builder.send().await?)
+        }
+    }
+
+    fn send_post(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+        let client = self.clone();
+        let (url, body, bearer_token) = request.into_parts();
+
+        async move {
+            let builder = client.post(url);
+            let builder = if let Some(token) = bearer_token {
+                builder.bearer_auth(token)
+            } else {
+                builder
+            };
+            let builder = if let Some(body) = body {
+                builder.body(body)
+            } else {
+                builder
+            };
+
+            Ok(builder.send().await?)
+        }
+    }
+}
 
 /// The client to influxdb
+#[cfg(feature = "reqwest")]
 #[derive(Debug, Clone)]
-pub struct Client {
+pub struct Client<T = ReqwestClient> {
     host: Url,
     db: String,
     authentication: Option<(String, String)>,
     jwt_token: Option<String>,
-    client: HttpClient,
+    client: T,
 }
 
-impl Client {
-    /// Create a new influxdb client with http
+/// The client to influxdb
+#[cfg(not(feature = "reqwest"))]
+#[derive(Debug, Clone)]
+pub struct Client<T> {
+    host: Url,
+    db: String,
+    authentication: Option<(String, String)>,
+    jwt_token: Option<String>,
+    client: T,
+}
+
+#[cfg(feature = "reqwest")]
+impl Client<ReqwestClient> {
+    /// Create a new influxdb client with the default reqwest client.
     pub fn new<T>(host: Url, db: T) -> Self
     where
         T: Into<String>,
@@ -33,14 +234,16 @@ impl Client {
             db: db.into(),
             authentication: None,
             jwt_token: None,
-            client: HttpClient::default(),
+            client: ReqwestClient::default(),
         }
     }
+}
 
-    /// Create a new influxdb client with custom reqwest's client.
-    pub fn new_with_client<T>(host: Url, db: T, client: HttpClient) -> Self
+impl<T> Client<T> {
+    /// Create a new influxdb client with a custom HTTP client.
+    pub fn new_with_client<U>(host: Url, db: U, client: T) -> Self
     where
-        T: Into<String>,
+        U: Into<String>,
     {
         Client {
             host,
@@ -52,26 +255,26 @@ impl Client {
     }
 
     /// Change the client's database
-    pub fn switch_database<T>(&mut self, database: T)
+    pub fn switch_database<U>(&mut self, database: U)
     where
-        T: Into<String>,
+        U: Into<String>,
     {
         self.db = database.into();
     }
 
     /// Change the client's user
-    pub fn set_authentication<T>(mut self, user: T, passwd: T) -> Self
+    pub fn set_authentication<U>(mut self, user: U, passwd: U) -> Self
     where
-        T: Into<String>,
+        U: Into<String>,
     {
         self.authentication = Some((user.into(), passwd.into()));
         self
     }
 
     /// Set the client's jwt token
-    pub fn set_jwt_token<T>(mut self, token: T) -> Self
+    pub fn set_jwt_token<U>(mut self, token: U) -> Self
     where
-        T: Into<String>,
+        U: Into<String>,
     {
         self.jwt_token = Some(token.into());
         self
@@ -82,34 +285,102 @@ impl Client {
         self.db.as_str()
     }
 
+    fn build_request(&self, url: Url) -> HttpRequest {
+        match self.jwt_token.as_deref() {
+            Some(token) => HttpRequest::new(url).with_bearer_token(token),
+            None => HttpRequest::new(url),
+        }
+    }
+
+    fn build_url(&self, key: &str, param: Option<Vec<(&str, &str)>>) -> Url {
+        let url = self.host.join(key).unwrap();
+
+        let mut authentication = Vec::new();
+
+        if let Some(ref t) = self.authentication {
+            authentication.push(("u", &t.0));
+            authentication.push(("p", &t.1));
+        }
+
+        let url = Url::parse_with_params(url.as_str(), authentication).unwrap();
+
+        if let Some(param) = param {
+            Url::parse_with_params(url.as_str(), param).unwrap()
+        } else {
+            url
+        }
+    }
+}
+
+fn validate_privilege(privilege: &str) -> Result<(), error::Error> {
+    if privilege.eq_ignore_ascii_case("read")
+        || privilege.eq_ignore_ascii_case("write")
+        || privilege.eq_ignore_ascii_case("all")
+    {
+        Ok(())
+    } else {
+        Err(error::Error::SyntaxError(format!(
+            "Invalid privilege '{}': must be one of 'read', 'write', or 'all'",
+            privilege
+        )))
+    }
+}
+
+async fn check_query_status<R, F, Fut>(res: R, parse_json: F) -> Result<R, error::Error>
+where
+    R: HttpResponse,
+    F: FnOnce(R) -> Fut,
+    Fut: Future<Output = Result<Query, error::Error>>,
+{
+    match res.status() {
+        200 => Ok(res),
+        400 => {
+            let json_data = parse_json(res).await?;
+            Err(query_syntax_error(&json_data, "Bad request"))
+        }
+        401 | 403 => Err(error::Error::InvalidCredentials(
+            "Invalid authentication credentials.".to_string(),
+        )),
+        _ => Err(error::Error::Unknow("There is something wrong".to_string())),
+    }
+}
+
+impl<T> Client<T>
+where
+    T: HttpClient,
+{
     /// Query whether the corresponding database exists, return bool
     pub fn ping(&self) -> impl Future<Output = bool> {
         let url = self.build_url("ping", None);
-        self.client.get(url).send().map(move |res| {
-            if let Ok(res) = res {
-                matches!(res.status().as_u16(), 204)
-            } else {
-                false
-            }
-        })
+        let request_future = self.client.get(self.build_request(url));
+
+        async move {
+            request_future
+                .await
+                .map(|res| matches!(res.status(), 204))
+                .unwrap_or(false)
+        }
     }
 
     /// Query the version of the database and return the version number
     pub fn get_version(&self) -> impl Future<Output = Option<String>> {
         let url = self.build_url("ping", None);
-        self.client.get(url).send().map(|res| {
-            if let Ok(res) = res {
-                match res.status().as_u16() {
-                    204 => match res.headers().get("X-Influxdb-Version") {
-                        Some(header) => header.to_str().ok().map(str::to_owned),
-                        None => Some(String::from("Don't know")),
+        let request_future = self.client.get(self.build_request(url));
+
+        async move {
+            if let Ok(res) = request_future.await {
+                match res.status() {
+                    204 => match res.header("X-Influxdb-Version") {
+                        Ok(Some(header)) => Some(header.to_owned()),
+                        Ok(None) => Some(String::from("Don't know")),
+                        Err(_) => None,
                     },
                     _ => None,
                 }
             } else {
                 None
             }
-        })
+        }
     }
 
     /// Write a point to the database
@@ -118,20 +389,37 @@ impl Client {
         point: Point<'a>,
         precision: Option<Precision>,
         rp: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + 'a {
-        let points = Points::new(point);
-        self.write_points(points, precision, rp)
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: WriteHttpClient,
+    {
+        let line = serialization::line_serialization(std::iter::once(&point));
+        self.write_line(line, precision, rp)
     }
 
     /// Write multiple points to the database
-    pub fn write_points<'a, T: IntoIterator<Item = impl Borrow<Point<'a>>>>(
+    pub fn write_points<'a, I: IntoIterator<Item = impl Borrow<Point<'a>>>>(
         &self,
-        points: T,
+        points: I,
         precision: Option<Precision>,
         rp: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: WriteHttpClient,
+    {
         let line = serialization::line_serialization(points);
+        self.write_line(line, precision, rp)
+    }
 
+    fn write_line(
+        &self,
+        line: String,
+        precision: Option<Precision>,
+        rp: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: WriteHttpClient,
+    {
         let mut param = vec![("db", self.db.as_str())];
 
         match precision {
@@ -144,23 +432,25 @@ impl Client {
         }
 
         let url = self.build_url("write", Some(param));
-        let fut = self.client.post(url).body(line).send();
+        let request = self.build_request(url).with_body(line);
+        let post_future = self.client.post_send(request);
 
         async move {
-            let res = fut.await?;
-            let status = res.status().as_u16();
-            let err = res.text().await?;
+            let (status, body) = post_future.await?;
+
+            if status == 204 {
+                return Ok(());
+            }
 
             match status {
-                204 => Ok(()),
-                400 => Err(error::Error::SyntaxError(serialization::conversion(&err))),
+                400 => Err(error::Error::SyntaxError(serialization::conversion(&body))),
                 401 | 403 => Err(error::Error::InvalidCredentials(
                     "Invalid authentication credentials.".to_string(),
                 )),
                 404 => Err(error::Error::DataBaseDoesNotExist(
-                    serialization::conversion(&err),
+                    serialization::conversion(&body),
                 )),
-                500 => Err(error::Error::RetentionPolicyDoesNotExist(err)),
+                500 => Err(error::Error::RetentionPolicyDoesNotExist(body)),
                 status => Err(error::Error::Unknow(format!(
                     "Received status code {}",
                     status
@@ -174,45 +464,126 @@ impl Client {
         &self,
         q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> {
-        self.query_raw(q, epoch).map_ok(|t| t.results)
+    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
+        let raw_future = self.query_raw_owned(q.to_owned(), epoch);
+        async move { Ok(raw_future.await?.results) }
     }
 
-    /// Query and return data, the data type is `Option<Vec<Node>>`
+    /// Query and return data through a future that borrows the configured HTTP client.
+    pub fn query_borrow(
+        &self,
+        q: &str,
+        epoch: Option<Precision>,
+    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> + use<'_, T> {
+        self.query_raw_borrow(q, epoch).map_ok(|t| t.results)
+    }
+
+    /// Query and return chunked query documents.
     pub fn query_chunked(
         &self,
         q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<ChunkedQuery<'static, IoRead<Cursor<Bytes>>>, error::Error>>
+    ) -> impl Future<
+        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
+    > + Send
+    + 'static
+    where
+        T: QueryHttpClient,
+        T::Response: QueryChunkedHttpResponse,
     {
-        self.query_raw_chunked(q, epoch)
+        self.query_raw_chunked_owned(q.to_owned(), epoch)
+    }
+
+    /// Query and return chunked query documents through a future that borrows the configured HTTP client.
+    pub fn query_chunked_borrow(
+        &self,
+        q: &str,
+        epoch: Option<Precision>,
+    ) -> impl Future<
+        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
+    > + use<'_, T>
+    where
+        T::Response: ChunkedHttpResponse,
+    {
+        self.query_raw_chunked_borrow(q, epoch)
     }
 
     /// Drop measurement
     pub fn drop_measurement(
         &self,
         measurement: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!(
             "Drop measurement {}",
             serialization::quote_ident(measurement)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::drop_measurement`].
+    pub fn drop_measurement_borrow(
+        &self,
+        measurement: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!(
+            "Drop measurement {}",
+            serialization::quote_ident(measurement)
+        );
+
+        self.execute_query_borrow(sql)
     }
 
     /// Create a new database in InfluxDB.
-    pub fn create_database(&self, dbname: &str) -> impl Future<Output = Result<(), error::Error>> {
+    pub fn create_database(
+        &self,
+        dbname: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!("Create database {}", serialization::quote_ident(dbname));
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::create_database`].
+    pub fn create_database_borrow(
+        &self,
+        dbname: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!("Create database {}", serialization::quote_ident(dbname));
+
+        self.execute_query_borrow(sql)
     }
 
     /// Drop a database from InfluxDB.
-    pub fn drop_database(&self, dbname: &str) -> impl Future<Output = Result<(), error::Error>> {
+    pub fn drop_database(
+        &self,
+        dbname: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!("Drop database {}", serialization::quote_ident(dbname));
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::drop_database`].
+    pub fn drop_database_borrow(
+        &self,
+        dbname: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!("Drop database {}", serialization::quote_ident(dbname));
+
+        self.execute_query_borrow(sql)
     }
 
     /// Create a new user in InfluxDB.
@@ -221,7 +592,10 @@ impl Client {
         user: &str,
         passwd: &str,
         admin: bool,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql: String = {
             if admin {
                 format!(
@@ -238,14 +612,54 @@ impl Client {
             }
         };
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::create_user`].
+    pub fn create_user_borrow(
+        &self,
+        user: &str,
+        passwd: &str,
+        admin: bool,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql: String = if admin {
+            format!(
+                "Create user {0} with password {1} with all privileges",
+                serialization::quote_ident(user),
+                serialization::quote_literal(passwd)
+            )
+        } else {
+            format!(
+                "Create user {0} WITH password {1}",
+                serialization::quote_ident(user),
+                serialization::quote_literal(passwd)
+            )
+        };
+
+        self.execute_query_borrow(sql)
     }
 
     /// Drop a user from InfluxDB.
-    pub fn drop_user(&self, user: &str) -> impl Future<Output = Result<(), error::Error>> {
+    pub fn drop_user(
+        &self,
+        user: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!("Drop user {}", serialization::quote_ident(user));
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::drop_user`].
+    pub fn drop_user_borrow(
+        &self,
+        user: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!("Drop user {}", serialization::quote_ident(user));
+
+        self.execute_query_borrow(sql)
     }
 
     /// Change the password of an existing user.
@@ -253,40 +667,90 @@ impl Client {
         &self,
         user: &str,
         passwd: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!(
             "Set password for {}={}",
             serialization::quote_ident(user),
             serialization::quote_literal(passwd)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::set_user_password`].
+    pub fn set_user_password_borrow(
+        &self,
+        user: &str,
+        passwd: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!(
+            "Set password for {}={}",
+            serialization::quote_ident(user),
+            serialization::quote_literal(passwd)
+        );
+
+        self.execute_query_borrow(sql)
     }
 
     /// Grant cluster administration privileges to a user.
     pub fn grant_admin_privileges(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!(
             "Grant all privileges to {}",
             serialization::quote_ident(user)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::grant_admin_privileges`].
+    pub fn grant_admin_privileges_borrow(
+        &self,
+        user: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!(
+            "Grant all privileges to {}",
+            serialization::quote_ident(user)
+        );
+
+        self.execute_query_borrow(sql)
     }
 
     /// Revoke cluster administration privileges from a user.
     pub fn revoke_admin_privileges(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
         let sql = format!(
             "Revoke all privileges from {}",
             serialization::quote_ident(user)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::revoke_admin_privileges`].
+    pub fn revoke_admin_privileges_borrow(
+        &self,
+        user: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let sql = format!(
+            "Revoke all privileges from {}",
+            serialization::quote_ident(user)
+        );
+
+        self.execute_query_borrow(sql)
     }
 
     /// Grant a privilege on a database to a user.
@@ -297,7 +761,32 @@ impl Client {
         user: &str,
         db: &str,
         privilege: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
+        match validate_privilege(privilege) {
+            Err(e) => futures::future::Either::Left(futures::future::ready(Err(e))),
+            Ok(()) => {
+                let sql = format!(
+                    "Grant {} on {} to {}",
+                    privilege,
+                    serialization::quote_ident(db),
+                    serialization::quote_ident(user)
+                );
+                futures::future::Either::Right(self.query_raw_owned(sql, None).map_ok(|_| ()))
+            }
+        }
+    }
+
+    /// Borrowing variant of [`Client::grant_privilege`].
+    pub fn grant_privilege_borrow(
+        &self,
+        user: &str,
+        db: &str,
+        privilege: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let validated = validate_privilege(privilege);
         let sql = format!(
             "Grant {} on {} to {}",
             privilege,
@@ -305,7 +794,10 @@ impl Client {
             serialization::quote_ident(user)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        async move {
+            validated?;
+            self.execute_query_borrow(sql).await
+        }
     }
 
     /// Revoke a privilege on a database from a user.
@@ -316,7 +808,32 @@ impl Client {
         user: &str,
         db: &str,
         privilege: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> {
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
+        match validate_privilege(privilege) {
+            Err(e) => futures::future::Either::Left(futures::future::ready(Err(e))),
+            Ok(()) => {
+                let sql = format!(
+                    "Revoke {0} on {1} from {2}",
+                    privilege,
+                    serialization::quote_ident(db),
+                    serialization::quote_ident(user)
+                );
+                futures::future::Either::Right(self.query_raw_owned(sql, None).map_ok(|_| ()))
+            }
+        }
+    }
+
+    /// Borrowing variant of [`Client::revoke_privilege`].
+    pub fn revoke_privilege_borrow(
+        &self,
+        user: &str,
+        db: &str,
+        privilege: &str,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let validated = validate_privilege(privilege);
         let sql = format!(
             "Revoke {0} on {1} from {2}",
             privilege,
@@ -324,7 +841,10 @@ impl Client {
             serialization::quote_ident(user)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        async move {
+            validated?;
+            self.execute_query_borrow(sql).await
+        }
     }
 
     /// Create a retention policy for a database.
@@ -341,14 +861,11 @@ impl Client {
         replication: &str,
         default: bool,
         db: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> {
-        let database = {
-            if let Some(t) = db {
-                t
-            } else {
-                &self.db
-            }
-        };
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
+        let database = { if let Some(t) = db { t } else { &self.db } };
 
         let sql: String = {
             if default {
@@ -370,7 +887,39 @@ impl Client {
             }
         };
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
+    }
+
+    /// Borrowing variant of [`Client::create_retention_policy`].
+    pub fn create_retention_policy_borrow(
+        &self,
+        name: &str,
+        duration: &str,
+        replication: &str,
+        default: bool,
+        db: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let database = if let Some(t) = db { t } else { &self.db };
+
+        let sql: String = if default {
+            format!(
+                "Create retention policy {} on {} duration {} replication {} default",
+                serialization::quote_ident(name),
+                serialization::quote_ident(database),
+                duration,
+                replication
+            )
+        } else {
+            format!(
+                "Create retention policy {} on {} duration {} replication {}",
+                serialization::quote_ident(name),
+                serialization::quote_ident(database),
+                duration,
+                replication
+            )
+        };
+
+        self.execute_query_borrow(sql)
     }
 
     /// Drop an existing retention policy for a database.
@@ -378,14 +927,11 @@ impl Client {
         &self,
         name: &str,
         db: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> {
-        let database = {
-            if let Some(t) = db {
-                t
-            } else {
-                &self.db
-            }
-        };
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
+        let database = { if let Some(t) = db { t } else { &self.db } };
 
         let sql = format!(
             "Drop retention policy {} on {}",
@@ -393,15 +939,32 @@ impl Client {
             serialization::quote_ident(database)
         );
 
-        self.query_raw(&sql, None).map_ok(|_| ())
+        self.query_raw_owned(sql, None).map_ok(|_| ())
     }
 
-    fn send_request(
+    /// Borrowing variant of [`Client::drop_retention_policy`].
+    pub fn drop_retention_policy_borrow(
+        &self,
+        name: &str,
+        db: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+        let database = if let Some(t) = db { t } else { &self.db };
+
+        let sql = format!(
+            "Drop retention policy {} on {}",
+            serialization::quote_ident(name),
+            serialization::quote_ident(database)
+        );
+
+        self.execute_query_borrow(sql)
+    }
+
+    fn build_query_request(
         &self,
         q: &str,
         epoch: Option<Precision>,
         chunked: bool,
-    ) -> impl Future<Output = Result<Response, error::Error>> {
+    ) -> (HttpRequest, bool) {
         let mut param = vec![("db", self.db.as_str()), ("q", q)];
 
         if let Some(ref t) = epoch {
@@ -413,89 +976,132 @@ impl Client {
         }
 
         let url = self.build_url("query", Some(param));
+        let request = self.build_request(url);
 
-        let q_lower = q.to_lowercase();
-        let mut builder = if q_lower.starts_with("select") && !q_lower.contains("into")
-            || q_lower.starts_with("show")
-        {
-            self.client.get(url)
+        let q_lower = q.to_ascii_lowercase();
+        let is_read_query = q_lower.starts_with("select") && !q_lower.contains("into")
+            || q_lower.starts_with("show");
+
+        (request, is_read_query)
+    }
+
+    fn send_request_borrow(
+        &self,
+        q: &str,
+        epoch: Option<Precision>,
+        chunked: bool,
+    ) -> impl Future<Output = Result<T::Response, error::Error>> + use<'_, T> {
+        let (request, is_read_query) = self.build_query_request(q, epoch, chunked);
+        let request_future = if is_read_query {
+            futures::future::Either::Left(self.client.get(request))
         } else {
-            self.client.post(url)
+            futures::future::Either::Right(self.client.post(request))
         };
 
-        if let Some(ref token) = self.jwt_token {
-            builder = builder.bearer_auth(token);
-        }
-
-        let resp_future = builder.send().boxed();
-
         async move {
-            let res = resp_future.await?;
-            match res.status().as_u16() {
-                200 => Ok(res),
-                400 => {
-                    let json_data: Query = res.json().await?;
-
-                    Err(error::Error::SyntaxError(serialization::conversion(
-                        &json_data.error.unwrap(),
-                    )))
-                }
-                401 | 403 => Err(error::Error::InvalidCredentials(
-                    "Invalid authentication credentials.".to_string(),
-                )),
-                _ => Err(error::Error::Unknow("There is something wrong".to_string())),
-            }
+            let res = request_future.await?;
+            check_query_status(res, |r| r.json::<Query>()).await
         }
     }
 
-    /// Query and return to the native json structure
-    fn query_raw(
-        &self,
-        q: &str,
-        epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<Query, error::Error>> {
-        let resp_future = self.send_request(q, epoch, false);
-        async move { Ok(resp_future.await?.json().await?) }
+    async fn send_request_owned(
+        client: T,
+        request: HttpRequest,
+        is_read_query: bool,
+    ) -> Result<T::Response, error::Error>
+    where
+        T: QueryHttpClient,
+    {
+        let res = if is_read_query {
+            client.send_get(request).await?
+        } else {
+            client.send_post(request).await?
+        };
+
+        check_query_status(res, |r| r.json_send::<Query>()).await
     }
 
-    /// Query and return to the native json structure
-    fn query_raw_chunked(
+    /// Query and return to the native json structure through the owned query path.
+    fn query_raw_owned(
+        &self,
+        q: String,
+        epoch: Option<Precision>,
+    ) -> impl Future<Output = Result<Query, error::Error>> + Send + 'static
+    where
+        T: QueryHttpClient,
+    {
+        let (request, is_read_query) = self.build_query_request(&q, epoch, false);
+        let client = self.client.clone();
+        let resp_future = Self::send_request_owned(client, request, is_read_query);
+        async move {
+            let query = resp_future.await?.json_send().await?;
+            ensure_query_success(query)
+        }
+    }
+
+    /// Query and return to the native json structure through a future that borrows the HTTP client.
+    fn query_raw_borrow(
         &self,
         q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<ChunkedQuery<'static, IoRead<Cursor<Bytes>>>, error::Error>>
+    ) -> impl Future<Output = Result<Query, error::Error>> + use<'_, T> {
+        let resp_future = self.send_request_borrow(q, epoch, false);
+        async move {
+            let query = resp_future.await?.json().await?;
+            ensure_query_success(query)
+        }
+    }
+
+    async fn execute_query_borrow(&self, sql: String) -> Result<(), error::Error> {
+        self.query_raw_borrow(&sql, None).await?;
+        Ok(())
+    }
+
+    /// Query and return chunked query documents through the owned query path.
+    fn query_raw_chunked_owned(
+        &self,
+        q: String,
+        epoch: Option<Precision>,
+    ) -> impl Future<
+        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
+    > + Send
+    + 'static
+    where
+        T: QueryHttpClient,
+        T::Response: QueryChunkedHttpResponse,
     {
-        let resp_future = self.send_request(q, epoch, true);
+        let (request, is_read_query) = self.build_query_request(&q, epoch, true);
+        let client = self.client.clone();
+        let resp_future = Self::send_request_owned(client, request, is_read_query);
         async move {
             let response = resp_future.await?;
-            let bytes = Cursor::new(response.bytes().await?);
-            let stream = serde_json::Deserializer::from_reader(bytes).into_iter::<Query>();
-            Ok(stream)
+            let stream = response.into_chunk_stream_send().await?;
+            Ok(ChunkedQuery::new(stream))
         }
     }
 
-    /// Constructs the full URL for an API call.
-    fn build_url(&self, key: &str, param: Option<Vec<(&str, &str)>>) -> Url {
-        let url = self.host.join(key).unwrap();
-
-        let mut authentication = Vec::new();
-
-        if let Some(ref t) = self.authentication {
-            authentication.push(("u", &t.0));
-            authentication.push(("p", &t.1));
-        }
-
-        let url = Url::parse_with_params(url.as_str(), authentication).unwrap();
-
-        if let Some(param) = param {
-            Url::parse_with_params(url.as_str(), param).unwrap()
-        } else {
-            url
+    /// Query and return chunked query documents through a future that borrows the HTTP client.
+    fn query_raw_chunked_borrow(
+        &self,
+        q: &str,
+        epoch: Option<Precision>,
+    ) -> impl Future<
+        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
+    > + use<'_, T>
+    where
+        T::Response: ChunkedHttpResponse,
+    {
+        let resp_future = self.send_request_borrow(q, epoch, true);
+        async move {
+            let response = resp_future.await?;
+            let stream = response.into_chunk_stream().await?;
+            Ok(ChunkedQuery::new(stream))
         }
     }
 }
 
-impl Default for Client {
+#[cfg(feature = "reqwest")]
+impl Default for Client<ReqwestClient> {
     /// connecting for default database `test` and host `http://localhost:8086`
     fn default() -> Self {
         Client::new(Url::parse("http://localhost:8086").unwrap(), "test")
@@ -561,5 +1167,1458 @@ impl FromIterator<SocketAddr> for UdpClient {
         }
 
         UdpClient { hosts }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Client;
+    use crate::{
+        Point, Precision, Query, error,
+        http::{
+            ChunkedHttpResponse, HttpClient, HttpRequest, HttpResponse, QueryChunkedHttpResponse,
+            QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+        },
+    };
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use serde::{Deserialize, de::DeserializeOwned};
+    use std::cell::Cell;
+    use std::collections::HashMap;
+    #[cfg(feature = "reqwest")]
+    use std::io::{Read, Write};
+    use std::marker::PhantomData;
+    #[cfg(feature = "reqwest")]
+    use std::net::TcpListener;
+    use std::rc::Rc;
+    use std::sync::{Arc, Mutex};
+    #[cfg(feature = "reqwest")]
+    use std::thread;
+    use url::Url;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedRequest {
+        method: &'static str,
+        url: String,
+        bearer_token: Option<String>,
+        body: Option<String>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct FakeResponse {
+        status: u16,
+        headers: HashMap<String, String>,
+        body: String,
+    }
+
+    impl FakeResponse {
+        fn json(status: u16, body: &str) -> Self {
+            Self {
+                status,
+                headers: HashMap::new(),
+                body: body.to_string(),
+            }
+        }
+
+        fn empty(status: u16) -> Self {
+            Self::json(status, "")
+        }
+    }
+
+    impl HttpResponse for FakeResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(self.headers.get(name).map(String::as_str))
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Ok(self.body)
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            Ok(Bytes::from(self.body))
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned,
+        {
+            serde_json::from_str(&self.body)
+                .map_err(|err| error::Error::Communication(err.to_string()))
+        }
+    }
+
+    impl QueryHttpResponse for FakeResponse {
+        async fn json_send<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned + 'static,
+        {
+            serde_json::from_str(&self.body)
+                .map_err(|err| error::Error::Communication(err.to_string()))
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingHttpClient {
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        responses: Arc<Mutex<Vec<FakeResponse>>>,
+    }
+
+    impl RecordingHttpClient {
+        fn new(responses: Vec<FakeResponse>) -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                responses: Arc::new(Mutex::new(responses.into_iter().rev().collect())),
+            }
+        }
+
+        fn take_requests(&self) -> Vec<RecordedRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+
+        fn record_with(
+            requests: Arc<Mutex<Vec<RecordedRequest>>>,
+            responses: Arc<Mutex<Vec<FakeResponse>>>,
+            method: &'static str,
+            request: HttpRequest,
+        ) -> Result<FakeResponse, error::Error> {
+            requests.lock().unwrap().push(RecordedRequest {
+                method,
+                url: request.url().to_string(),
+                bearer_token: request.bearer_token().map(str::to_owned),
+                body: request.body().map(str::to_owned),
+            });
+
+            responses
+                .lock()
+                .unwrap()
+                .pop()
+                .ok_or_else(|| error::Error::Unknow("missing fake response".to_string()))
+        }
+    }
+
+    struct NonSyncWriteHttpClient {
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        status: Cell<u16>,
+    }
+
+    impl NonSyncWriteHttpClient {
+        fn new(status: u16) -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                status: Cell::new(status),
+            }
+        }
+
+        fn take_requests(&self) -> Vec<RecordedRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    struct BorrowingGetHttpClient {
+        select_response: String,
+        get_calls: Cell<u16>,
+    }
+
+    impl BorrowingGetHttpClient {
+        fn new(select_response: &str) -> Self {
+            Self {
+                select_response: select_response.to_string(),
+                get_calls: Cell::new(0),
+            }
+        }
+    }
+
+    struct BorrowingPostHttpClient {
+        post_calls: Cell<u16>,
+    }
+
+    impl BorrowingPostHttpClient {
+        fn new() -> Self {
+            Self {
+                post_calls: Cell::new(0),
+            }
+        }
+    }
+
+    struct BorrowingQueryGetHttpClient {
+        get_calls: Cell<u16>,
+    }
+
+    impl BorrowingQueryGetHttpClient {
+        fn new() -> Self {
+            Self {
+                get_calls: Cell::new(0),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct SplitQueryHttpClient {
+        response_body: String,
+        get_calls: Cell<u16>,
+        post_calls: Cell<u16>,
+    }
+
+    impl SplitQueryHttpClient {
+        fn new(response_body: &str) -> Self {
+            Self {
+                response_body: response_body.to_string(),
+                get_calls: Cell::new(0),
+                post_calls: Cell::new(0),
+            }
+        }
+    }
+
+    struct NonSendResponseHttpClient {
+        response_body: String,
+    }
+
+    impl NonSendResponseHttpClient {
+        fn new(response_body: &str) -> Self {
+            Self {
+                response_body: response_body.to_string(),
+            }
+        }
+    }
+
+    struct NonSendBodyFutureHttpClient {
+        response_body: String,
+    }
+
+    impl NonSendBodyFutureHttpClient {
+        fn new(response_body: &str) -> Self {
+            Self {
+                response_body: response_body.to_string(),
+            }
+        }
+    }
+
+    struct NonSendResponse {
+        status: u16,
+        body: Rc<String>,
+    }
+
+    struct NonSendBodyFutureResponse {
+        status: u16,
+        body: Rc<String>,
+    }
+
+    enum VersionHeader {
+        Missing,
+        Valid(String),
+        InvalidUtf8,
+    }
+
+    struct VersionHeaderResponse {
+        status: u16,
+        version_header: VersionHeader,
+    }
+
+    struct VersionHeaderHttpClient {
+        response: VersionHeaderResponse,
+    }
+
+    impl VersionHeaderHttpClient {
+        fn new(response: VersionHeaderResponse) -> Self {
+            Self { response }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct NonSendQueryResult {
+        value: String,
+        _not_send: PhantomData<Rc<()>>,
+    }
+
+    #[derive(Clone)]
+    struct ChunkedFakeResponse {
+        status: u16,
+        segments: Vec<Vec<u8>>,
+    }
+
+    #[derive(Clone)]
+    struct ChunkedHttpClient {
+        response: ChunkedFakeResponse,
+    }
+
+    struct BorrowingChunkedHttpClient {
+        response: ChunkedFakeResponse,
+    }
+
+    impl<'de> Deserialize<'de> for NonSendQueryResult {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct Helper {
+                value: String,
+            }
+
+            let helper = Helper::deserialize(deserializer)?;
+            Ok(Self {
+                value: helper.value,
+                _not_send: PhantomData,
+            })
+        }
+    }
+
+    impl HttpClient for RecordingHttpClient {
+        type Response = FakeResponse;
+
+        fn get(
+            &self,
+            request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let requests = Arc::clone(&self.requests);
+            let responses = Arc::clone(&self.responses);
+
+            async move { Self::record_with(requests, responses, "GET", request) }
+        }
+
+        fn post(
+            &self,
+            request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let requests = Arc::clone(&self.requests);
+            let responses = Arc::clone(&self.responses);
+
+            async move { Self::record_with(requests, responses, "POST", request) }
+        }
+    }
+
+    impl WriteHttpClient for RecordingHttpClient {
+        fn post_send(
+            &self,
+            request: HttpRequest,
+        ) -> impl Future<Output = Result<(u16, String), error::Error>> + Send + 'static + use<>
+        {
+            let requests = Arc::clone(&self.requests);
+            let responses = Arc::clone(&self.responses);
+
+            async move {
+                let res = Self::record_with(requests, responses, "POST", request)?;
+                Ok((res.status, res.body))
+            }
+        }
+    }
+
+    impl QueryHttpClient for RecordingHttpClient {
+        fn send_get(
+            &self,
+            request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            let requests = Arc::clone(&self.requests);
+            let responses = Arc::clone(&self.responses);
+
+            async move { Self::record_with(requests, responses, "GET", request) }
+        }
+
+        fn send_post(
+            &self,
+            request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            let requests = Arc::clone(&self.requests);
+            let responses = Arc::clone(&self.responses);
+
+            async move { Self::record_with(requests, responses, "POST", request) }
+        }
+    }
+
+    impl HttpClient for NonSyncWriteHttpClient {
+        type Response = FakeResponse;
+
+        async fn get(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "GET is not used in this test".to_string(),
+            ))
+        }
+
+        fn post(
+            &self,
+            request: HttpRequest,
+        ) -> impl std::future::Future<Output = Result<Self::Response, error::Error>> {
+            let requests = Arc::clone(&self.requests);
+            let status = self.status.get();
+
+            async move {
+                requests.lock().unwrap().push(RecordedRequest {
+                    method: "POST",
+                    url: request.url().to_string(),
+                    bearer_token: request.bearer_token().map(str::to_owned),
+                    body: request.body().map(str::to_owned),
+                });
+
+                Ok(FakeResponse::empty(status))
+            }
+        }
+    }
+
+    impl WriteHttpClient for NonSyncWriteHttpClient {
+        fn post_send(
+            &self,
+            request: HttpRequest,
+        ) -> impl std::future::Future<Output = Result<(u16, String), error::Error>>
+        + Send
+        + 'static
+        + use<> {
+            let requests = Arc::clone(&self.requests);
+            let status = self.status.get();
+
+            async move {
+                requests.lock().unwrap().push(RecordedRequest {
+                    method: "POST",
+                    url: request.url().to_string(),
+                    bearer_token: request.bearer_token().map(str::to_owned),
+                    body: request.body().map(str::to_owned),
+                });
+
+                Ok((status, String::new()))
+            }
+        }
+    }
+
+    impl HttpClient for BorrowingGetHttpClient {
+        type Response = FakeResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            self.get_calls.set(self.get_calls.get() + 1);
+
+            async {
+                Ok(FakeResponse::json(
+                    200,
+                    &format!(r#"{{"value":"{}"}}"#, self.select_response),
+                ))
+            }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl HttpClient for BorrowingPostHttpClient {
+        type Response = FakeResponse;
+
+        async fn get(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "GET is not used in this test".to_string(),
+            ))
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            self.post_calls.set(self.post_calls.get() + 1);
+            Ok(FakeResponse::json(200, r#"{"results":[]}"#))
+        }
+    }
+
+    impl HttpClient for BorrowingQueryGetHttpClient {
+        type Response = FakeResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            self.get_calls.set(self.get_calls.get() + 1);
+
+            async {
+                Ok(FakeResponse::json(
+                    200,
+                    r#"{"results":[{"statement_id":0,"series":null}]}"#,
+                ))
+            }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl HttpClient for SplitQueryHttpClient {
+        type Response = FakeResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            self.get_calls.set(self.get_calls.get() + 1);
+
+            async {
+                Ok(FakeResponse::json(
+                    200,
+                    &format!(
+                        r#"{{"results":[{{"statement_id":0,"value":"{}"}}]}}"#,
+                        self.response_body
+                    ),
+                ))
+            }
+        }
+
+        fn post(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            self.post_calls.set(self.post_calls.get() + 1);
+            async { Ok(FakeResponse::json(200, r#"{"results":[]}"#)) }
+        }
+    }
+
+    impl QueryHttpClient for SplitQueryHttpClient {
+        fn send_get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            let response_body = self.response_body.clone();
+
+            async move {
+                Ok(FakeResponse::json(
+                    200,
+                    &format!(
+                        r#"{{"results":[{{"statement_id":0,"value":"{}"}}]}}"#,
+                        response_body
+                    ),
+                ))
+            }
+        }
+
+        fn send_post(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            let response = FakeResponse::json(200, r#"{"results":[]}"#);
+            async move { Ok(response) }
+        }
+    }
+
+    impl HttpResponse for NonSendResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, _name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(None)
+        }
+
+        fn text(self) -> impl Future<Output = Result<String, error::Error>> {
+            let body = (*self.body).clone();
+            async move { Ok(body) }
+        }
+
+        fn bytes(self) -> impl Future<Output = Result<Bytes, error::Error>> {
+            let body = (*self.body).clone();
+            async move { Ok(Bytes::from(body)) }
+        }
+
+        fn json<T>(self) -> impl Future<Output = Result<T, error::Error>>
+        where
+            T: DeserializeOwned,
+        {
+            let body = (*self.body).clone();
+            async move {
+                serde_json::from_str(&body)
+                    .map_err(|err| error::Error::Communication(err.to_string()))
+            }
+        }
+    }
+
+    impl HttpClient for NonSendResponseHttpClient {
+        type Response = NonSendResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let body = self.response_body.clone();
+
+            async move {
+                Ok(NonSendResponse {
+                    status: 200,
+                    body: Rc::new(body),
+                })
+            }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl HttpResponse for NonSendBodyFutureResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, _name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(None)
+        }
+
+        fn text(self) -> impl Future<Output = Result<String, error::Error>> {
+            let body = self.body;
+            async move { Ok((*body).clone()) }
+        }
+
+        fn bytes(self) -> impl Future<Output = Result<Bytes, error::Error>> {
+            let body = self.body;
+            async move { Ok(Bytes::from((*body).clone())) }
+        }
+
+        fn json<T>(self) -> impl Future<Output = Result<T, error::Error>>
+        where
+            T: DeserializeOwned,
+        {
+            let body = self.body;
+            async move {
+                serde_json::from_str(body.as_ref())
+                    .map_err(|err| error::Error::Communication(err.to_string()))
+            }
+        }
+    }
+
+    impl HttpClient for NonSendBodyFutureHttpClient {
+        type Response = NonSendBodyFutureResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let body = self.response_body.clone();
+
+            async move {
+                Ok(NonSendBodyFutureResponse {
+                    status: 200,
+                    body: Rc::new(body),
+                })
+            }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl HttpResponse for VersionHeaderResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, name: &str) -> Result<Option<&str>, error::Error> {
+            if name != "X-Influxdb-Version" {
+                return Ok(None);
+            }
+
+            match &self.version_header {
+                VersionHeader::Missing => Ok(None),
+                VersionHeader::Valid(value) => Ok(Some(value.as_str())),
+                VersionHeader::InvalidUtf8 => Err(error::Error::Communication(
+                    "invalid header value".to_string(),
+                )),
+            }
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Ok(String::new())
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            Ok(Bytes::new())
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned,
+        {
+            Err(error::Error::Unknow(
+                "JSON is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl HttpClient for VersionHeaderHttpClient {
+        type Response = VersionHeaderResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let response = VersionHeaderResponse {
+                status: self.response.status,
+                version_header: match &self.response.version_header {
+                    VersionHeader::Missing => VersionHeader::Missing,
+                    VersionHeader::Valid(value) => VersionHeader::Valid(value.clone()),
+                    VersionHeader::InvalidUtf8 => VersionHeader::InvalidUtf8,
+                },
+            };
+
+            async move { Ok(response) }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl HttpResponse for ChunkedFakeResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, _name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(None)
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Err(error::Error::Unknow(
+                "text is not used in this test".to_string(),
+            ))
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            panic!("chunked query should not eagerly buffer the whole response body")
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned,
+        {
+            Err(error::Error::Unknow(
+                "json is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl ChunkedHttpResponse for ChunkedFakeResponse {
+        type Stream = futures::stream::Iter<
+            std::iter::Map<std::vec::IntoIter<Vec<u8>>, fn(Vec<u8>) -> Result<Bytes, error::Error>>,
+        >;
+
+        async fn into_chunk_stream(self) -> Result<Self::Stream, error::Error> {
+            fn into_bytes(segment: Vec<u8>) -> Result<Bytes, error::Error> {
+                Ok(Bytes::from(segment))
+            }
+
+            Ok(futures::stream::iter(self.segments.into_iter().map(
+                into_bytes as fn(Vec<u8>) -> Result<Bytes, error::Error>,
+            )))
+        }
+    }
+
+    impl QueryHttpResponse for ChunkedFakeResponse {
+        async fn json_send<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned + 'static,
+        {
+            Err(error::Error::Unknow(
+                "json_send is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl QueryChunkedHttpResponse for ChunkedFakeResponse {
+        async fn into_chunk_stream_send(self) -> Result<Self::Stream, error::Error> {
+            self.into_chunk_stream().await
+        }
+    }
+
+    impl ChunkedHttpClient {
+        fn new(response: ChunkedFakeResponse) -> Self {
+            Self { response }
+        }
+    }
+
+    impl BorrowingChunkedHttpClient {
+        fn new(response: ChunkedFakeResponse) -> Self {
+            Self { response }
+        }
+    }
+
+    impl HttpClient for ChunkedHttpClient {
+        type Response = ChunkedFakeResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let response = self.response.clone();
+            async move { Ok(response) }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl QueryHttpClient for ChunkedHttpClient {
+        fn send_get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            let response = self.response.clone();
+            async move { Ok(response) }
+        }
+
+        fn send_post(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            let error = error::Error::Unknow("POST is not used in this test".to_string());
+            async move { Err(error) }
+        }
+    }
+
+    impl HttpClient for BorrowingChunkedHttpClient {
+        type Response = ChunkedFakeResponse;
+
+        fn get(
+            &self,
+            _request: HttpRequest,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            let response = self.response.clone();
+            async move { Ok(response) }
+        }
+
+        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
+            Err(error::Error::Unknow(
+                "POST is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Runtime::new().unwrap().block_on(future)
+    }
+
+    fn assert_send_static<F>(future: F) -> F
+    where
+        F: std::future::Future + Send + 'static,
+    {
+        future
+    }
+
+    #[test]
+    fn custom_http_client_select_query_uses_get_and_preserves_jwt_token() {
+        let http_client =
+            RecordingHttpClient::new(vec![FakeResponse::json(200, r#"{"results":[]}"#)]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        )
+        .set_jwt_token("jwt-token");
+
+        let result = block_on(client.query("select * from cpu", None)).unwrap();
+
+        assert_eq!(result, Some(Vec::new()));
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "GET");
+        assert_eq!(requests[0].bearer_token.as_deref(), Some("jwt-token"));
+        assert!(requests[0].url.contains("/query"));
+        assert!(requests[0].url.contains("db=metrics"));
+        assert!(requests[0].url.contains("q=select"));
+    }
+
+    #[test]
+    fn ping_preserves_jwt_token() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse::empty(204)]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        )
+        .set_jwt_token("jwt-token");
+
+        let ping = block_on(client.ping());
+
+        assert!(ping);
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "GET");
+        assert_eq!(requests[0].bearer_token.as_deref(), Some("jwt-token"));
+        assert!(requests[0].url.contains("/ping"));
+    }
+
+    #[test]
+    fn get_version_preserves_jwt_token() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse {
+            status: 204,
+            headers: HashMap::from([("X-Influxdb-Version".to_string(), "1.8.10".to_string())]),
+            body: String::new(),
+        }]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        )
+        .set_jwt_token("jwt-token");
+
+        let version = block_on(client.get_version());
+
+        assert_eq!(version.as_deref(), Some("1.8.10"));
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "GET");
+        assert_eq!(requests[0].bearer_token.as_deref(), Some("jwt-token"));
+        assert!(requests[0].url.contains("/ping"));
+    }
+
+    #[test]
+    fn custom_http_client_non_select_query_uses_post() {
+        let http_client =
+            RecordingHttpClient::new(vec![FakeResponse::json(200, r#"{"results":[]}"#)]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        );
+
+        block_on(client.query("create database metrics", None)).unwrap();
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+    }
+
+    #[test]
+    fn query_returns_statement_error_from_400_response() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse::json(
+            400,
+            r#"{"results":[{"statement_id":0,"error":"bad query"}]}"#,
+        )]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        );
+
+        let result = block_on(client.query("create database metrics", None));
+
+        assert_eq!(
+            result,
+            Err(error::Error::SyntaxError("bad query".to_string()))
+        );
+    }
+
+    #[test]
+    fn query_returns_statement_error_from_200_response() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse::json(
+            200,
+            r#"{"results":[{"statement_id":0,"error":"bad query"}]}"#,
+        )]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        );
+
+        let result = block_on(client.query("create database metrics", None));
+
+        assert_eq!(
+            result,
+            Err(error::Error::SyntaxError("bad query".to_string()))
+        );
+    }
+
+    #[test]
+    fn query_chunked_uses_chunk_stream_without_buffering_the_whole_body() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            ChunkedHttpClient::new(ChunkedFakeResponse {
+                status: 200,
+                segments: vec![
+                    br#"{"results":[{"statement_id":0"#.to_vec(),
+                    br#","series":null}]}"#.to_vec(),
+                ],
+            }),
+        );
+
+        block_on(async {
+            let mut query = client
+                .query_chunked("select value from cpu", None)
+                .await
+                .unwrap();
+            let first = query.next().await.unwrap().unwrap();
+
+            assert_eq!(first.results.unwrap()[0].statement_id, Some(0));
+            assert!(query.next().await.is_none());
+        });
+    }
+
+    #[test]
+    fn query_chunked_returns_statement_error_from_chunk() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            ChunkedHttpClient::new(ChunkedFakeResponse {
+                status: 200,
+                segments: vec![
+                    br#"{"results":[{"statement_id":0"#.to_vec(),
+                    br#","error":"bad query"}]}"#.to_vec(),
+                ],
+            }),
+        );
+
+        block_on(async {
+            let mut query = client
+                .query_chunked("select value from cpu", None)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                query.next().await.unwrap(),
+                Err(error::Error::SyntaxError("bad query".to_string()))
+            );
+            assert!(query.next().await.is_none());
+        });
+    }
+
+    #[test]
+    fn query_chunked_setup_can_be_spawned_with_cloneable_http_client() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            ChunkedHttpClient::new(ChunkedFakeResponse {
+                status: 200,
+                segments: vec![
+                    br#"{"results":[{"statement_id":0"#.to_vec(),
+                    br#","series":null}]}"#.to_vec(),
+                ],
+            }),
+        );
+
+        block_on(async {
+            let mut query = tokio::spawn(client.query_chunked("select value from cpu", None))
+                .await
+                .unwrap()
+                .unwrap();
+
+            let first = query.next().await.unwrap().unwrap();
+            assert_eq!(first.results.unwrap()[0].statement_id, Some(0));
+            assert!(query.next().await.is_none());
+        });
+    }
+
+    #[cfg(feature = "reqwest")]
+    #[test]
+    fn reqwest_query_chunked_streams_queries_on_current_thread_runtime() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).unwrap();
+
+            let first = br#"{"results":[{"statement_id":0,"series":null}]}
+"#;
+            let second = br#"{"results":[{"statement_id":1,"series":null}]}
+"#;
+
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: application/json\r\n\r\n{:X}\r\n",
+                first.len()
+            )
+            .unwrap();
+            stream.write_all(first).unwrap();
+            stream.write_all(b"\r\n").unwrap();
+            write!(stream, "{:X}\r\n", second.len()).unwrap();
+            stream.write_all(second).unwrap();
+            stream.write_all(b"\r\n0\r\n\r\n").unwrap();
+            stream.flush().unwrap();
+        });
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let client =
+                    Client::new(Url::parse(&format!("http://{address}")).unwrap(), "metrics");
+                let mut query = client
+                    .query_chunked("select value from cpu", None)
+                    .await
+                    .unwrap();
+
+                let first = query.next().await.unwrap().unwrap();
+                let second = query.next().await.unwrap().unwrap();
+
+                assert_eq!(first.results.unwrap()[0].statement_id, Some(0));
+                assert_eq!(second.results.unwrap()[0].statement_id, Some(1));
+                assert!(query.next().await.is_none());
+            });
+
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn custom_http_client_write_points_preserves_jwt_token() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse::empty(204)]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        )
+        .set_jwt_token("jwt-token");
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        block_on(client.write_point(point, Some(Precision::Seconds), None)).unwrap();
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].bearer_token.as_deref(), Some("jwt-token"));
+        assert_eq!(requests[0].body.as_deref(), Some("cpu value=1i 42\n"));
+        assert!(requests[0].url.contains("/write"));
+    }
+
+    #[test]
+    fn custom_http_client_write_points_uses_post_with_body() {
+        let http_client = RecordingHttpClient::new(vec![FakeResponse::empty(204)]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        );
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        block_on(client.write_point(point, Some(Precision::Seconds), None)).unwrap();
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].body.as_deref(), Some("cpu value=1i 42\n"));
+        assert!(requests[0].url.contains("/write"));
+        assert!(requests[0].url.contains("precision=s"));
+    }
+
+    #[test]
+    fn write_point_can_be_spawned_with_non_sync_http_client() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            NonSyncWriteHttpClient::new(204),
+        );
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        block_on(async {
+            tokio::spawn(client.write_point(point, Some(Precision::Seconds), None))
+                .await
+                .unwrap()
+                .unwrap();
+        });
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].body.as_deref(), Some("cpu value=1i 42\n"));
+    }
+
+    #[test]
+    fn query_can_be_spawned_with_cloneable_http_client() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            RecordingHttpClient::new(vec![FakeResponse::json(
+                200,
+                r#"{"results":[{"statement_id":0,"series":null}]}"#,
+            )]),
+        );
+
+        block_on(async {
+            let result = tokio::spawn(client.query("select value from cpu", None))
+                .await
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(result.unwrap()[0].statement_id, Some(0));
+        });
+    }
+
+    #[test]
+    fn owned_query_futures_require_spawn_safe_query_transport() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            SplitQueryHttpClient::new("owned"),
+        );
+
+        let _query = assert_send_static(client.query("select value from cpu", None));
+        let _management = assert_send_static(client.drop_measurement("cpu"));
+    }
+
+    #[test]
+    fn send_request_borrow_supports_get_futures_that_borrow_non_sync_clients() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingGetHttpClient::new("borrowed"),
+        );
+
+        let response: NonSendQueryResult = block_on(async {
+            client
+                .send_request_borrow("select value from cpu", None, false)
+                .await
+                .unwrap()
+                .json::<NonSendQueryResult>()
+                .await
+                .unwrap()
+        });
+
+        assert_eq!(
+            response,
+            NonSendQueryResult {
+                value: "borrowed".to_string(),
+                _not_send: PhantomData,
+            }
+        );
+        assert_eq!(client.client.get_calls.get(), 1);
+    }
+
+    #[test]
+    fn query_borrow_supports_get_futures_that_borrow_non_sync_clients() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingQueryGetHttpClient::new(),
+        );
+
+        let result = block_on(client.query_borrow("select value from cpu", None)).unwrap();
+
+        assert_eq!(result.unwrap()[0].statement_id, Some(0));
+        assert_eq!(client.client.get_calls.get(), 1);
+    }
+
+    #[test]
+    fn send_request_supports_post_futures_that_borrow_non_sync_clients() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingPostHttpClient::new(),
+        );
+
+        let query = block_on(async {
+            client
+                .send_request_borrow("create database metrics", None, false)
+                .await
+                .unwrap()
+                .json::<Query>()
+                .await
+                .unwrap()
+        });
+
+        assert_eq!(query.results, Some(Vec::new()));
+        assert_eq!(client.client.post_calls.get(), 1);
+    }
+
+    #[test]
+    fn query_borrow_supports_post_futures_that_borrow_non_sync_clients() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingPostHttpClient::new(),
+        );
+
+        let result = block_on(client.query_borrow("create database metrics", None)).unwrap();
+
+        assert_eq!(result, Some(Vec::new()));
+        assert_eq!(client.client.post_calls.get(), 1);
+    }
+
+    #[test]
+    fn query_backed_management_apis_offer_borrow_variants() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingPostHttpClient::new(),
+        );
+
+        block_on(async {
+            client.drop_measurement_borrow("cpu").await.unwrap();
+            client.create_database_borrow("metrics_2").await.unwrap();
+            client.drop_database_borrow("metrics_2").await.unwrap();
+            client
+                .create_user_borrow("alice", "secret", false)
+                .await
+                .unwrap();
+            client.drop_user_borrow("alice").await.unwrap();
+            client
+                .set_user_password_borrow("alice", "secret_2")
+                .await
+                .unwrap();
+            client.grant_admin_privileges_borrow("alice").await.unwrap();
+            client
+                .revoke_admin_privileges_borrow("alice")
+                .await
+                .unwrap();
+            client
+                .grant_privilege_borrow("alice", "metrics", "read")
+                .await
+                .unwrap();
+            client
+                .revoke_privilege_borrow("alice", "metrics", "read")
+                .await
+                .unwrap();
+            client
+                .create_retention_policy_borrow("rp", "1h", "1", false, None)
+                .await
+                .unwrap();
+            client
+                .drop_retention_policy_borrow("rp", None)
+                .await
+                .unwrap();
+        });
+
+        assert_eq!(client.client.post_calls.get(), 12);
+    }
+
+    #[test]
+    fn query_chunked_borrow_supports_non_clone_http_client() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingChunkedHttpClient::new(ChunkedFakeResponse {
+                status: 200,
+                segments: vec![
+                    br#"{"results":[{"statement_id":0"#.to_vec(),
+                    br#","series":null}]}"#.to_vec(),
+                ],
+            }),
+        );
+
+        block_on(async {
+            let mut query = client
+                .query_chunked_borrow("select value from cpu", None)
+                .await
+                .unwrap();
+            let first = query.next().await.unwrap().unwrap();
+
+            assert_eq!(first.results.unwrap()[0].statement_id, Some(0));
+            assert!(query.next().await.is_none());
+        });
+    }
+
+    #[test]
+    fn query_supports_non_send_response_types() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            NonSendResponseHttpClient::new(r#"{"value":"owned"}"#),
+        );
+
+        let response: NonSendQueryResult = block_on(async {
+            client
+                .send_request_borrow("select value from cpu", None, false)
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap()
+        });
+
+        assert_eq!(
+            response,
+            NonSendQueryResult {
+                value: "owned".to_string(),
+                _not_send: PhantomData,
+            }
+        );
+    }
+
+    #[test]
+    fn query_supports_non_send_body_futures() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            NonSendBodyFutureHttpClient::new(r#"{"value":"body"}"#),
+        );
+
+        let response: NonSendQueryResult = block_on(async {
+            client
+                .send_request_borrow("select value from cpu", None, false)
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap()
+        });
+
+        assert_eq!(
+            response,
+            NonSendQueryResult {
+                value: "body".to_string(),
+                _not_send: PhantomData,
+            }
+        );
+    }
+
+    #[test]
+    fn get_version_returns_none_for_invalid_header_values() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            VersionHeaderHttpClient::new(VersionHeaderResponse {
+                status: 204,
+                version_header: VersionHeader::InvalidUtf8,
+            }),
+        );
+
+        let version = block_on(client.get_version());
+
+        assert_eq!(version, None);
+    }
+
+    #[test]
+    fn get_version_returns_fallback_when_header_is_missing() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            VersionHeaderHttpClient::new(VersionHeaderResponse {
+                status: 204,
+                version_header: VersionHeader::Missing,
+            }),
+        );
+
+        let version = block_on(client.get_version());
+
+        assert_eq!(version.as_deref(), Some("Don't know"));
+    }
+
+    #[test]
+    fn get_version_returns_header_value_when_it_is_valid() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            VersionHeaderHttpClient::new(VersionHeaderResponse {
+                status: 204,
+                version_header: VersionHeader::Valid("1.8.10".to_string()),
+            }),
+        );
+
+        let version = block_on(client.get_version());
+
+        assert_eq!(version.as_deref(), Some("1.8.10"));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,15 +18,39 @@ use reqwest::{Client as ReqwestClient, Response as ReqwestResponse};
 use crate::{
     ChunkedQuery, Node, Point, Points, Precision, Query, error,
     http::{
-        ChunkedHttpResponse, HttpClient, HttpRequest, HttpResponse, QueryChunkedHttpResponse,
-        QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+        BorrowChunkedHttpResponse, BorrowHttpClient, BorrowHttpResponse, ChunkedHttpResponse,
+        HttpClient, HttpMethod, HttpRequest, HttpResponse,
     },
     keys::{ensure_query_success, query_syntax_error},
     serialization,
 };
 
 #[cfg(feature = "reqwest")]
-impl HttpResponse for ReqwestResponse {
+fn reqwest_request_builder(
+    client: &ReqwestClient,
+    method: HttpMethod,
+    request: HttpRequest<'_>,
+) -> reqwest::RequestBuilder {
+    let (url, body, bearer_token) = request.into_parts();
+    let builder = match method {
+        HttpMethod::Get => client.get(url),
+        HttpMethod::Post => client.post(url),
+    };
+    let builder = if let Some(token) = bearer_token {
+        builder.bearer_auth(token.as_ref())
+    } else {
+        builder
+    };
+
+    if let Some(body) = body {
+        builder.body(body.into_owned())
+    } else {
+        builder
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl BorrowHttpResponse for ReqwestResponse {
     fn status(&self) -> u16 {
         self.status().as_u16()
     }
@@ -58,12 +82,46 @@ impl HttpResponse for ReqwestResponse {
 }
 
 #[cfg(feature = "reqwest")]
-impl QueryHttpResponse for ReqwestResponse {
-    async fn json_send<T>(self) -> Result<T, error::Error>
+impl HttpResponse for ReqwestResponse {
+    fn status(&self) -> u16 {
+        self.status().as_u16()
+    }
+
+    fn header(&self, name: &str) -> Result<Option<&str>, error::Error> {
+        match self.headers().get(name) {
+            Some(value) => value
+                .to_str()
+                .map(Some)
+                .map_err(|err| error::Error::Communication(err.to_string())),
+            None => Ok(None),
+        }
+    }
+
+    async fn text(self) -> Result<String, error::Error> {
+        Ok(reqwest::Response::text(self).await?)
+    }
+
+    async fn bytes(self) -> Result<Bytes, error::Error> {
+        Ok(reqwest::Response::bytes(self).await?)
+    }
+
+    async fn json<T>(self) -> Result<T, error::Error>
     where
         T: DeserializeOwned + 'static,
     {
         Ok(reqwest::Response::json(self).await?)
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl BorrowChunkedHttpResponse for ReqwestResponse {
+    type Stream =
+        std::pin::Pin<Box<dyn Stream<Item = Result<Bytes, error::Error>> + Send + 'static>>;
+
+    async fn into_chunk_stream(self) -> Result<Self::Stream, error::Error> {
+        Ok(Box::pin(
+            reqwest::Response::bytes_stream(self).map_err(Into::into),
+        ))
     }
 }
 
@@ -80,122 +138,37 @@ impl ChunkedHttpResponse for ReqwestResponse {
 }
 
 #[cfg(feature = "reqwest")]
-impl QueryChunkedHttpResponse for ReqwestResponse {
-    async fn into_chunk_stream_send(self) -> Result<Self::Stream, error::Error> {
-        Ok(Box::pin(
-            reqwest::Response::bytes_stream(self).map_err(Into::into),
-        ))
-    }
-}
-
-#[cfg(feature = "reqwest")]
-impl WriteHttpClient for ReqwestClient {
-    fn post_send(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<(u16, String), error::Error>> + Send + 'static + use<> {
-        let (url, body, bearer_token) = request.into_parts();
-        let builder = self.post(url);
-        let builder = if let Some(token) = bearer_token {
-            builder.bearer_auth(token)
-        } else {
-            builder
-        };
-        let builder = if let Some(body) = body {
-            builder.body(body)
-        } else {
-            builder
-        };
-
-        async move {
-            let res = builder.send().await?;
-            let status = res.status().as_u16();
-            let body = reqwest::Response::text(res).await?;
-            Ok((status, body))
-        }
-    }
-}
-
-#[cfg(feature = "reqwest")]
 impl HttpClient for ReqwestClient {
     type Response = ReqwestResponse;
 
-    fn get(
+    fn send(
         &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> {
-        let (url, _body, bearer_token) = request.into_parts();
-        let builder = if let Some(token) = bearer_token {
-            self.get(url).bearer_auth(token)
-        } else {
-            self.get(url)
-        };
+        method: HttpMethod,
+        request: HttpRequest<'static>,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<> {
+        let client = self.clone();
 
-        async move { Ok(builder.send().await?) }
-    }
-
-    fn post(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'_> {
-        let (url, body, bearer_token) = request.into_parts();
-        let builder = self.post(url);
-        let builder = if let Some(token) = bearer_token {
-            builder.bearer_auth(token)
-        } else {
-            builder
-        };
-        let builder = if let Some(body) = body {
-            builder.body(body)
-        } else {
-            builder
-        };
-
-        async move { Ok(builder.send().await?) }
+        async move {
+            Ok(reqwest_request_builder(&client, method, request)
+                .send()
+                .await?)
+        }
     }
 }
 
 #[cfg(feature = "reqwest")]
-impl QueryHttpClient for ReqwestClient {
-    fn send_get(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
-        let client = self.clone();
-        let (url, _body, bearer_token) = request.into_parts();
+impl BorrowHttpClient for ReqwestClient {
+    type Response = ReqwestResponse;
 
+    fn send<'a>(
+        &'a self,
+        method: HttpMethod,
+        request: HttpRequest<'a>,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
         async move {
-            let builder = if let Some(token) = bearer_token {
-                client.get(url).bearer_auth(token)
-            } else {
-                client.get(url)
-            };
-
-            Ok(builder.send().await?)
-        }
-    }
-
-    fn send_post(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
-        let client = self.clone();
-        let (url, body, bearer_token) = request.into_parts();
-
-        async move {
-            let builder = client.post(url);
-            let builder = if let Some(token) = bearer_token {
-                builder.bearer_auth(token)
-            } else {
-                builder
-            };
-            let builder = if let Some(body) = body {
-                builder.body(body)
-            } else {
-                builder
-            };
-
-            Ok(builder.send().await?)
+            Ok(reqwest_request_builder(self, method, request)
+                .send()
+                .await?)
         }
     }
 }
@@ -285,7 +258,7 @@ impl<T> Client<T> {
         self.db.as_str()
     }
 
-    fn build_request(&self, url: Url) -> HttpRequest {
+    fn build_request(&self, url: Url) -> HttpRequest<'_> {
         match self.jwt_token.as_deref() {
             Some(token) => HttpRequest::new(url).with_bearer_token(token),
             None => HttpRequest::new(url),
@@ -326,6 +299,25 @@ fn validate_privilege(privilege: &str) -> Result<(), error::Error> {
     }
 }
 
+async fn check_query_status_borrow<R, F, Fut>(res: R, parse_json: F) -> Result<R, error::Error>
+where
+    R: BorrowHttpResponse,
+    F: FnOnce(R) -> Fut,
+    Fut: Future<Output = Result<Query, error::Error>>,
+{
+    match res.status() {
+        200 => Ok(res),
+        400 => {
+            let json_data = parse_json(res).await?;
+            Err(query_syntax_error(&json_data, "Bad request"))
+        }
+        401 | 403 => Err(error::Error::InvalidCredentials(
+            "Invalid authentication credentials.".to_string(),
+        )),
+        _ => Err(error::Error::Unknow("There is something wrong".to_string())),
+    }
+}
+
 async fn check_query_status<R, F, Fut>(res: R, parse_json: F) -> Result<R, error::Error>
 where
     R: HttpResponse,
@@ -345,14 +337,59 @@ where
     }
 }
 
-impl<T> Client<T>
-where
-    T: HttpClient,
-{
-    /// Query whether the corresponding database exists, return bool
-    pub fn ping(&self) -> impl Future<Output = bool> {
-        let url = self.build_url("ping", None);
-        let request_future = self.client.get(self.build_request(url));
+fn map_write_response(status: u16, body: String) -> Result<(), error::Error> {
+    match status {
+        400 => Err(error::Error::SyntaxError(serialization::conversion(&body))),
+        401 | 403 => Err(error::Error::InvalidCredentials(
+            "Invalid authentication credentials.".to_string(),
+        )),
+        404 => Err(error::Error::DataBaseDoesNotExist(
+            serialization::conversion(&body),
+        )),
+        500 => Err(error::Error::RetentionPolicyDoesNotExist(body)),
+        status => Err(error::Error::Unknow(format!(
+            "Received status code {}",
+            status
+        ))),
+    }
+}
+
+fn map_version_header(header: Result<Option<&str>, error::Error>) -> Option<String> {
+    match header {
+        Ok(Some(header)) => Some(header.to_owned()),
+        Ok(None) => Some(String::from("Don't know")),
+        Err(_) => None,
+    }
+}
+
+impl<T> Client<T> {
+    fn build_ping_request(&self) -> HttpRequest<'_> {
+        self.build_request(self.build_url("ping", None))
+    }
+
+    /// Query whether the corresponding database exists.
+    pub fn ping(&self) -> impl Future<Output = bool> + Send + 'static + use<T>
+    where
+        T: HttpClient,
+    {
+        let response_future = self
+            .client
+            .send(HttpMethod::Get, self.build_ping_request().into_owned());
+
+        async move {
+            response_future
+                .await
+                .map(|res| matches!(res.status(), 204))
+                .unwrap_or(false)
+        }
+    }
+
+    /// Borrowing variant of [`Client::ping`].
+    pub fn ping_borrow(&self) -> impl Future<Output = bool> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
+        let request_future = self.client.send(HttpMethod::Get, self.build_ping_request());
 
         async move {
             request_future
@@ -362,19 +399,38 @@ where
         }
     }
 
-    /// Query the version of the database and return the version number
-    pub fn get_version(&self) -> impl Future<Output = Option<String>> {
-        let url = self.build_url("ping", None);
-        let request_future = self.client.get(self.build_request(url));
+    /// Query the version of the database and return the version number.
+    pub fn get_version(&self) -> impl Future<Output = Option<String>> + Send + 'static + use<T>
+    where
+        T: HttpClient,
+    {
+        let response_future = self
+            .client
+            .send(HttpMethod::Get, self.build_ping_request().into_owned());
+
+        async move {
+            if let Ok(res) = response_future.await {
+                match res.status() {
+                    204 => map_version_header(res.header("X-Influxdb-Version")),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Borrowing variant of [`Client::get_version`].
+    pub fn get_version_borrow(&self) -> impl Future<Output = Option<String>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
+        let request_future = self.client.send(HttpMethod::Get, self.build_ping_request());
 
         async move {
             if let Ok(res) = request_future.await {
                 match res.status() {
-                    204 => match res.header("X-Influxdb-Version") {
-                        Ok(Some(header)) => Some(header.to_owned()),
-                        Ok(None) => Some(String::from("Don't know")),
-                        Err(_) => None,
-                    },
+                    204 => map_version_header(res.header("X-Influxdb-Version")),
                     _ => None,
                 }
             } else {
@@ -389,37 +445,66 @@ where
         point: Point<'a>,
         precision: Option<Precision>,
         rp: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: WriteHttpClient,
+        T: HttpClient,
     {
         let line = serialization::line_serialization(std::iter::once(&point));
         self.write_line(line, precision, rp)
     }
 
+    /// Write a point to the database through a future that borrows the configured HTTP client.
+    pub fn write_point_borrow<'a>(
+        &self,
+        point: Point<'a>,
+        precision: Option<Precision>,
+        rp: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>>
+    where
+        T: BorrowHttpClient,
+    {
+        let line = serialization::line_serialization(std::iter::once(&point));
+        self.write_line_borrow(line, precision, rp)
+    }
+
     /// Write multiple points to the database
-    pub fn write_points<'a, I: IntoIterator<Item = impl Borrow<Point<'a>>>>(
+    pub fn write_points<'a, I, P>(
         &self,
         points: I,
         precision: Option<Precision>,
         rp: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T, I, P>
     where
-        T: WriteHttpClient,
+        I: IntoIterator<Item = P>,
+        P: Borrow<Point<'a>>,
+        T: HttpClient,
     {
         let line = serialization::line_serialization(points);
         self.write_line(line, precision, rp)
     }
 
-    fn write_line(
+    /// Write multiple points through a future that borrows the configured HTTP client.
+    pub fn write_points_borrow<'a, I, P>(
+        &self,
+        points: I,
+        precision: Option<Precision>,
+        rp: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>>
+    where
+        I: IntoIterator<Item = P>,
+        P: Borrow<Point<'a>>,
+        T: BorrowHttpClient,
+    {
+        let line = serialization::line_serialization(points);
+        self.write_line_borrow(line, precision, rp)
+    }
+
+    fn build_write_request(
         &self,
         line: String,
         precision: Option<Precision>,
         rp: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
-    where
-        T: WriteHttpClient,
-    {
+    ) -> HttpRequest<'_> {
         let mut param = vec![("db", self.db.as_str())];
 
         match precision {
@@ -432,30 +517,56 @@ where
         }
 
         let url = self.build_url("write", Some(param));
-        let request = self.build_request(url).with_body(line);
-        let post_future = self.client.post_send(request);
+        self.build_request(url).with_body(line)
+    }
+
+    fn write_line(
+        &self,
+        line: String,
+        precision: Option<Precision>,
+        rp: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
+    where
+        T: HttpClient,
+    {
+        let request = self.build_write_request(line, precision, rp).into_owned();
+        let response_future = self.client.send(HttpMethod::Post, request);
 
         async move {
-            let (status, body) = post_future.await?;
+            let response = response_future.await?;
+            let status = response.status();
 
             if status == 204 {
                 return Ok(());
             }
 
-            match status {
-                400 => Err(error::Error::SyntaxError(serialization::conversion(&body))),
-                401 | 403 => Err(error::Error::InvalidCredentials(
-                    "Invalid authentication credentials.".to_string(),
-                )),
-                404 => Err(error::Error::DataBaseDoesNotExist(
-                    serialization::conversion(&body),
-                )),
-                500 => Err(error::Error::RetentionPolicyDoesNotExist(body)),
-                status => Err(error::Error::Unknow(format!(
-                    "Received status code {}",
-                    status
-                ))),
+            let body = response.text().await?;
+            map_write_response(status, body)
+        }
+    }
+
+    fn write_line_borrow(
+        &self,
+        line: String,
+        precision: Option<Precision>,
+        rp: Option<&str>,
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
+        let request = self.build_write_request(line, precision, rp);
+        let response_future = self.client.send(HttpMethod::Post, request);
+
+        async move {
+            let response = response_future.await?;
+            let status = response.status();
+
+            if status == 204 {
+                return Ok(());
             }
+
+            let body = response.text().await?;
+            map_write_response(status, body)
         }
     }
 
@@ -464,11 +575,11 @@ where
         &self,
         q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
-        let raw_future = self.query_raw_owned(q.to_owned(), epoch);
+        let raw_future = self.query_raw(q, epoch);
         async move { Ok(raw_future.await?.results) }
     }
 
@@ -477,7 +588,10 @@ where
         &self,
         q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<Option<Vec<Node>>, error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         self.query_raw_borrow(q, epoch).map_ok(|t| t.results)
     }
 
@@ -487,14 +601,19 @@ where
         q: &str,
         epoch: Option<Precision>,
     ) -> impl Future<
-        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
-    > + Send
+        Output = Result<
+            ChunkedQuery<<<T as HttpClient>::Response as ChunkedHttpResponse>::Stream>,
+            error::Error,
+        >,
+    >
+    + Send
     + 'static
+    + use<T>
     where
-        T: QueryHttpClient,
-        T::Response: QueryChunkedHttpResponse,
+        T: HttpClient,
+        <T as HttpClient>::Response: ChunkedHttpResponse,
     {
-        self.query_raw_chunked_owned(q.to_owned(), epoch)
+        self.query_raw_chunked(q, epoch)
     }
 
     /// Query and return chunked query documents through a future that borrows the configured HTTP client.
@@ -503,10 +622,14 @@ where
         q: &str,
         epoch: Option<Precision>,
     ) -> impl Future<
-        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
+        Output = Result<
+            ChunkedQuery<<<T as BorrowHttpClient>::Response as BorrowChunkedHttpResponse>::Stream>,
+            error::Error,
+        >,
     > + use<'_, T>
     where
-        T::Response: ChunkedHttpResponse,
+        T: BorrowHttpClient,
+        <T as BorrowHttpClient>::Response: BorrowChunkedHttpResponse,
     {
         self.query_raw_chunked_borrow(q, epoch)
     }
@@ -515,23 +638,26 @@ where
     pub fn drop_measurement(
         &self,
         measurement: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!(
             "Drop measurement {}",
             serialization::quote_ident(measurement)
         );
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::drop_measurement`].
     pub fn drop_measurement_borrow(
         &self,
         measurement: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!(
             "Drop measurement {}",
             serialization::quote_ident(measurement)
@@ -544,20 +670,23 @@ where
     pub fn create_database(
         &self,
         dbname: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!("Create database {}", serialization::quote_ident(dbname));
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::create_database`].
     pub fn create_database_borrow(
         &self,
         dbname: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!("Create database {}", serialization::quote_ident(dbname));
 
         self.execute_query_borrow(sql)
@@ -567,20 +696,23 @@ where
     pub fn drop_database(
         &self,
         dbname: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!("Drop database {}", serialization::quote_ident(dbname));
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::drop_database`].
     pub fn drop_database_borrow(
         &self,
         dbname: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!("Drop database {}", serialization::quote_ident(dbname));
 
         self.execute_query_borrow(sql)
@@ -592,9 +724,9 @@ where
         user: &str,
         passwd: &str,
         admin: bool,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql: String = {
             if admin {
@@ -612,7 +744,7 @@ where
             }
         };
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::create_user`].
@@ -621,7 +753,10 @@ where
         user: &str,
         passwd: &str,
         admin: bool,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql: String = if admin {
             format!(
                 "Create user {0} with password {1} with all privileges",
@@ -643,20 +778,23 @@ where
     pub fn drop_user(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!("Drop user {}", serialization::quote_ident(user));
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::drop_user`].
     pub fn drop_user_borrow(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!("Drop user {}", serialization::quote_ident(user));
 
         self.execute_query_borrow(sql)
@@ -667,9 +805,9 @@ where
         &self,
         user: &str,
         passwd: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!(
             "Set password for {}={}",
@@ -677,7 +815,7 @@ where
             serialization::quote_literal(passwd)
         );
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::set_user_password`].
@@ -685,7 +823,10 @@ where
         &self,
         user: &str,
         passwd: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!(
             "Set password for {}={}",
             serialization::quote_ident(user),
@@ -699,23 +840,26 @@ where
     pub fn grant_admin_privileges(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!(
             "Grant all privileges to {}",
             serialization::quote_ident(user)
         );
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::grant_admin_privileges`].
     pub fn grant_admin_privileges_borrow(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!(
             "Grant all privileges to {}",
             serialization::quote_ident(user)
@@ -728,23 +872,26 @@ where
     pub fn revoke_admin_privileges(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let sql = format!(
             "Revoke all privileges from {}",
             serialization::quote_ident(user)
         );
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::revoke_admin_privileges`].
     pub fn revoke_admin_privileges_borrow(
         &self,
         user: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let sql = format!(
             "Revoke all privileges from {}",
             serialization::quote_ident(user)
@@ -761,9 +908,9 @@ where
         user: &str,
         db: &str,
         privilege: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         match validate_privilege(privilege) {
             Err(e) => futures::future::Either::Left(futures::future::ready(Err(e))),
@@ -774,7 +921,7 @@ where
                     serialization::quote_ident(db),
                     serialization::quote_ident(user)
                 );
-                futures::future::Either::Right(self.query_raw_owned(sql, None).map_ok(|_| ()))
+                futures::future::Either::Right(self.query_raw(&sql, None).map_ok(|_| ()))
             }
         }
     }
@@ -785,7 +932,10 @@ where
         user: &str,
         db: &str,
         privilege: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let validated = validate_privilege(privilege);
         let sql = format!(
             "Grant {} on {} to {}",
@@ -808,9 +958,9 @@ where
         user: &str,
         db: &str,
         privilege: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         match validate_privilege(privilege) {
             Err(e) => futures::future::Either::Left(futures::future::ready(Err(e))),
@@ -821,7 +971,7 @@ where
                     serialization::quote_ident(db),
                     serialization::quote_ident(user)
                 );
-                futures::future::Either::Right(self.query_raw_owned(sql, None).map_ok(|_| ()))
+                futures::future::Either::Right(self.query_raw(&sql, None).map_ok(|_| ()))
             }
         }
     }
@@ -832,7 +982,10 @@ where
         user: &str,
         db: &str,
         privilege: &str,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let validated = validate_privilege(privilege);
         let sql = format!(
             "Revoke {0} on {1} from {2}",
@@ -861,9 +1014,9 @@ where
         replication: &str,
         default: bool,
         db: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let database = { if let Some(t) = db { t } else { &self.db } };
 
@@ -887,7 +1040,7 @@ where
             }
         };
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::create_retention_policy`].
@@ -898,7 +1051,10 @@ where
         replication: &str,
         default: bool,
         db: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let database = if let Some(t) = db { t } else { &self.db };
 
         let sql: String = if default {
@@ -927,9 +1083,9 @@ where
         &self,
         name: &str,
         db: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<(), error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let database = { if let Some(t) = db { t } else { &self.db } };
 
@@ -939,7 +1095,7 @@ where
             serialization::quote_ident(database)
         );
 
-        self.query_raw_owned(sql, None).map_ok(|_| ())
+        self.query_raw(&sql, None).map_ok(|_| ())
     }
 
     /// Borrowing variant of [`Client::drop_retention_policy`].
@@ -947,7 +1103,10 @@ where
         &self,
         name: &str,
         db: Option<&str>,
-    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<(), error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let database = if let Some(t) = db { t } else { &self.db };
 
         let sql = format!(
@@ -964,7 +1123,7 @@ where
         q: &str,
         epoch: Option<Precision>,
         chunked: bool,
-    ) -> (HttpRequest, bool) {
+    ) -> (HttpRequest<'_>, bool) {
         let mut param = vec![("db", self.db.as_str()), ("q", q)];
 
         if let Some(ref t) = epoch {
@@ -990,51 +1149,58 @@ where
         q: &str,
         epoch: Option<Precision>,
         chunked: bool,
-    ) -> impl Future<Output = Result<T::Response, error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<<T as BorrowHttpClient>::Response, error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let (request, is_read_query) = self.build_query_request(q, epoch, chunked);
-        let request_future = if is_read_query {
-            futures::future::Either::Left(self.client.get(request))
+        let method = if is_read_query {
+            HttpMethod::Get
         } else {
-            futures::future::Either::Right(self.client.post(request))
+            HttpMethod::Post
         };
+        let request_future = self.client.send(method, request);
 
         async move {
             let res = request_future.await?;
+            check_query_status_borrow(res, |r| r.json::<Query>()).await
+        }
+    }
+
+    fn send_request(
+        &self,
+        method: HttpMethod,
+        request: HttpRequest<'static>,
+    ) -> impl Future<Output = Result<<T as HttpClient>::Response, error::Error>> + Send + 'static + use<T>
+    where
+        T: HttpClient,
+    {
+        let response_future = self.client.send(method, request);
+
+        async move {
+            let res = response_future.await?;
             check_query_status(res, |r| r.json::<Query>()).await
         }
     }
 
-    async fn send_request_owned(
-        client: T,
-        request: HttpRequest,
-        is_read_query: bool,
-    ) -> Result<T::Response, error::Error>
-    where
-        T: QueryHttpClient,
-    {
-        let res = if is_read_query {
-            client.send_get(request).await?
-        } else {
-            client.send_post(request).await?
-        };
-
-        check_query_status(res, |r| r.json_send::<Query>()).await
-    }
-
-    /// Query and return to the native json structure through the owned query path.
-    fn query_raw_owned(
+    /// Query and return to the native json structure through the spawn-safe query path.
+    fn query_raw(
         &self,
-        q: String,
+        q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<Query, error::Error>> + Send + 'static
+    ) -> impl Future<Output = Result<Query, error::Error>> + Send + 'static + use<T>
     where
-        T: QueryHttpClient,
+        T: HttpClient,
     {
         let (request, is_read_query) = self.build_query_request(&q, epoch, false);
-        let client = self.client.clone();
-        let resp_future = Self::send_request_owned(client, request, is_read_query);
+        let method = if is_read_query {
+            HttpMethod::Get
+        } else {
+            HttpMethod::Post
+        };
+        let resp_future = self.send_request(method, request.into_owned());
         async move {
-            let query = resp_future.await?.json_send().await?;
+            let query = resp_future.await?.json().await?;
             ensure_query_success(query)
         }
     }
@@ -1044,7 +1210,10 @@ where
         &self,
         q: &str,
         epoch: Option<Precision>,
-    ) -> impl Future<Output = Result<Query, error::Error>> + use<'_, T> {
+    ) -> impl Future<Output = Result<Query, error::Error>> + use<'_, T>
+    where
+        T: BorrowHttpClient,
+    {
         let resp_future = self.send_request_borrow(q, epoch, false);
         async move {
             let query = resp_future.await?.json().await?;
@@ -1052,30 +1221,42 @@ where
         }
     }
 
-    async fn execute_query_borrow(&self, sql: String) -> Result<(), error::Error> {
+    async fn execute_query_borrow(&self, sql: String) -> Result<(), error::Error>
+    where
+        T: BorrowHttpClient,
+    {
         self.query_raw_borrow(&sql, None).await?;
         Ok(())
     }
 
-    /// Query and return chunked query documents through the owned query path.
-    fn query_raw_chunked_owned(
+    /// Query and return chunked query documents through the spawn-safe query path.
+    fn query_raw_chunked(
         &self,
-        q: String,
+        q: &str,
         epoch: Option<Precision>,
     ) -> impl Future<
-        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
-    > + Send
+        Output = Result<
+            ChunkedQuery<<<T as HttpClient>::Response as ChunkedHttpResponse>::Stream>,
+            error::Error,
+        >,
+    >
+    + Send
     + 'static
+    + use<T>
     where
-        T: QueryHttpClient,
-        T::Response: QueryChunkedHttpResponse,
+        T: HttpClient,
+        <T as HttpClient>::Response: ChunkedHttpResponse,
     {
         let (request, is_read_query) = self.build_query_request(&q, epoch, true);
-        let client = self.client.clone();
-        let resp_future = Self::send_request_owned(client, request, is_read_query);
+        let method = if is_read_query {
+            HttpMethod::Get
+        } else {
+            HttpMethod::Post
+        };
+        let resp_future = self.send_request(method, request.into_owned());
         async move {
             let response = resp_future.await?;
-            let stream = response.into_chunk_stream_send().await?;
+            let stream = response.into_chunk_stream().await?;
             Ok(ChunkedQuery::new(stream))
         }
     }
@@ -1086,10 +1267,14 @@ where
         q: &str,
         epoch: Option<Precision>,
     ) -> impl Future<
-        Output = Result<ChunkedQuery<<T::Response as ChunkedHttpResponse>::Stream>, error::Error>,
+        Output = Result<
+            ChunkedQuery<<<T as BorrowHttpClient>::Response as BorrowChunkedHttpResponse>::Stream>,
+            error::Error,
+        >,
     > + use<'_, T>
     where
-        T::Response: ChunkedHttpResponse,
+        T: BorrowHttpClient,
+        <T as BorrowHttpClient>::Response: BorrowChunkedHttpResponse,
     {
         let resp_future = self.send_request_borrow(q, epoch, true);
         async move {
@@ -1176,8 +1361,8 @@ mod tests {
     use crate::{
         Point, Precision, Query, error,
         http::{
-            ChunkedHttpResponse, HttpClient, HttpRequest, HttpResponse, QueryChunkedHttpResponse,
-            QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+            BorrowChunkedHttpResponse, BorrowHttpClient, BorrowHttpResponse, ChunkedHttpResponse,
+            HttpClient, HttpMethod, HttpRequest, HttpResponse,
         },
     };
     use bytes::Bytes;
@@ -1225,7 +1410,7 @@ mod tests {
         }
     }
 
-    impl HttpResponse for FakeResponse {
+    impl BorrowHttpResponse for FakeResponse {
         fn status(&self) -> u16 {
             self.status
         }
@@ -1251,8 +1436,50 @@ mod tests {
         }
     }
 
-    impl QueryHttpResponse for FakeResponse {
-        async fn json_send<T>(self) -> Result<T, error::Error>
+    impl HttpResponse for FakeResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(self.headers.get(name).map(String::as_str))
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Ok(self.body)
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            Ok(Bytes::from(self.body))
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned + 'static,
+        {
+            serde_json::from_str(&self.body)
+                .map_err(|err| error::Error::Communication(err.to_string()))
+        }
+    }
+
+    impl HttpResponse for OwnedOnlyResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(self.headers.get(name).map(String::as_str))
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Ok(self.body)
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            Ok(Bytes::from(self.body))
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
         where
             T: DeserializeOwned + 'static,
         {
@@ -1283,7 +1510,7 @@ mod tests {
             requests: Arc<Mutex<Vec<RecordedRequest>>>,
             responses: Arc<Mutex<Vec<FakeResponse>>>,
             method: &'static str,
-            request: HttpRequest,
+            request: HttpRequest<'_>,
         ) -> Result<FakeResponse, error::Error> {
             requests.lock().unwrap().push(RecordedRequest {
                 method,
@@ -1340,6 +1567,26 @@ mod tests {
         fn new() -> Self {
             Self {
                 post_calls: Cell::new(0),
+            }
+        }
+    }
+
+    struct BorrowingWriteHttpClient {
+        requests: Rc<Cell<u16>>,
+        last_request: Rc<std::cell::RefCell<Option<RecordedRequest>>>,
+        response: FakeResponse,
+    }
+
+    impl BorrowingWriteHttpClient {
+        fn new() -> Self {
+            Self::with_response(FakeResponse::empty(204))
+        }
+
+        fn with_response(response: FakeResponse) -> Self {
+            Self {
+                requests: Rc::new(Cell::new(0)),
+                last_request: Rc::new(std::cell::RefCell::new(None)),
+                response,
             }
         }
     }
@@ -1449,6 +1696,52 @@ mod tests {
         response: ChunkedFakeResponse,
     }
 
+    #[derive(Clone)]
+    struct OwnedOnlyResponse {
+        status: u16,
+        headers: HashMap<String, String>,
+        body: String,
+    }
+
+    impl OwnedOnlyResponse {
+        fn json(status: u16, body: &str) -> Self {
+            Self {
+                status,
+                headers: HashMap::new(),
+                body: body.to_string(),
+            }
+        }
+
+        fn empty(status: u16) -> Self {
+            Self::json(status, "")
+        }
+
+        fn with_header(status: u16, name: &str, value: &str) -> Self {
+            Self {
+                status,
+                headers: HashMap::from([(name.to_string(), value.to_string())]),
+                body: String::new(),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct OwnedOnlyChunkedResponse {
+        status: u16,
+        segments: Vec<Vec<u8>>,
+    }
+
+    #[derive(Clone)]
+    struct OwnedOnlyHttpClient {
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        responses: Arc<Mutex<Vec<OwnedOnlyResponse>>>,
+    }
+
+    #[derive(Clone)]
+    struct OwnedOnlyChunkedHttpClient {
+        response: OwnedOnlyChunkedResponse,
+    }
+
     impl<'de> Deserialize<'de> for NonSendQueryResult {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
@@ -1467,85 +1760,116 @@ mod tests {
         }
     }
 
-    impl HttpClient for RecordingHttpClient {
+    impl BorrowHttpClient for RecordingHttpClient {
         type Response = FakeResponse;
 
-        fn get(
-            &self,
-            request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
             let requests = Arc::clone(&self.requests);
             let responses = Arc::clone(&self.responses);
+            let method = match method {
+                HttpMethod::Get => "GET",
+                HttpMethod::Post => "POST",
+            };
 
-            async move { Self::record_with(requests, responses, "GET", request) }
-        }
-
-        fn post(
-            &self,
-            request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
-            let requests = Arc::clone(&self.requests);
-            let responses = Arc::clone(&self.responses);
-
-            async move { Self::record_with(requests, responses, "POST", request) }
+            async move { Self::record_with(requests, responses, method, request) }
         }
     }
 
-    impl WriteHttpClient for RecordingHttpClient {
-        fn post_send(
+    impl HttpClient for OwnedOnlyHttpClient {
+        type Response = OwnedOnlyResponse;
+
+        fn send(
             &self,
-            request: HttpRequest,
-        ) -> impl Future<Output = Result<(u16, String), error::Error>> + Send + 'static + use<>
+            method: HttpMethod,
+            request: HttpRequest<'static>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<>
         {
             let requests = Arc::clone(&self.requests);
             let responses = Arc::clone(&self.responses);
 
             async move {
-                let res = Self::record_with(requests, responses, "POST", request)?;
-                Ok((res.status, res.body))
+                Self::record_with(
+                    requests,
+                    responses,
+                    match method {
+                        HttpMethod::Get => "GET",
+                        HttpMethod::Post => "POST",
+                    },
+                    request,
+                )
             }
         }
     }
 
-    impl QueryHttpClient for RecordingHttpClient {
-        fn send_get(
+    impl HttpClient for OwnedOnlyChunkedHttpClient {
+        type Response = OwnedOnlyChunkedResponse;
+
+        fn send(
             &self,
-            request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
-            let requests = Arc::clone(&self.requests);
-            let responses = Arc::clone(&self.responses);
+            method: HttpMethod,
+            _request: HttpRequest<'static>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<>
+        {
+            let response = self.response.clone();
+            let error = error::Error::Unknow("POST is not used in this test".to_string());
 
-            async move { Self::record_with(requests, responses, "GET", request) }
-        }
-
-        fn send_post(
-            &self,
-            request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
-            let requests = Arc::clone(&self.requests);
-            let responses = Arc::clone(&self.responses);
-
-            async move { Self::record_with(requests, responses, "POST", request) }
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(response),
+                    HttpMethod::Post => Err(error),
+                }
+            }
         }
     }
 
-    impl HttpClient for NonSyncWriteHttpClient {
+    impl HttpClient for RecordingHttpClient {
         type Response = FakeResponse;
 
-        async fn get(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "GET is not used in this test".to_string(),
-            ))
-        }
-
-        fn post(
+        fn send(
             &self,
-            request: HttpRequest,
-        ) -> impl std::future::Future<Output = Result<Self::Response, error::Error>> {
+            method: HttpMethod,
+            request: HttpRequest<'static>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<>
+        {
+            let requests = Arc::clone(&self.requests);
+            let responses = Arc::clone(&self.responses);
+
+            async move {
+                Self::record_with(
+                    requests,
+                    responses,
+                    match method {
+                        HttpMethod::Get => "GET",
+                        HttpMethod::Post => "POST",
+                    },
+                    request,
+                )
+            }
+        }
+    }
+
+    impl BorrowHttpClient for NonSyncWriteHttpClient {
+        type Response = FakeResponse;
+
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
             let requests = Arc::clone(&self.requests);
             let status = self.status.get();
 
             async move {
+                if method != HttpMethod::Post {
+                    return Err(error::Error::Unknow(
+                        "GET is not used in this test".to_string(),
+                    ));
+                }
+
                 requests.lock().unwrap().push(RecordedRequest {
                     method: "POST",
                     url: request.url().to_string(),
@@ -1558,11 +1882,14 @@ mod tests {
         }
     }
 
-    impl WriteHttpClient for NonSyncWriteHttpClient {
-        fn post_send(
+    impl HttpClient for NonSyncWriteHttpClient {
+        type Response = FakeResponse;
+
+        fn send(
             &self,
-            request: HttpRequest,
-        ) -> impl std::future::Future<Output = Result<(u16, String), error::Error>>
+            method: HttpMethod,
+            request: HttpRequest<'static>,
+        ) -> impl std::future::Future<Output = Result<Self::Response, error::Error>>
         + Send
         + 'static
         + use<> {
@@ -1570,6 +1897,12 @@ mod tests {
             let status = self.status.get();
 
             async move {
+                if method != HttpMethod::Post {
+                    return Err(error::Error::Unknow(
+                        "GET is not used in this test".to_string(),
+                    ));
+                }
+
                 requests.lock().unwrap().push(RecordedRequest {
                     method: "POST",
                     url: request.url().to_string(),
@@ -1577,131 +1910,170 @@ mod tests {
                     body: request.body().map(str::to_owned),
                 });
 
-                Ok((status, String::new()))
+                Ok(FakeResponse::empty(status))
             }
         }
     }
 
-    impl HttpClient for BorrowingGetHttpClient {
+    impl BorrowHttpClient for BorrowingGetHttpClient {
         type Response = FakeResponse;
 
-        fn get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
-            self.get_calls.set(self.get_calls.get() + 1);
-
-            async {
-                Ok(FakeResponse::json(
-                    200,
-                    &format!(r#"{{"value":"{}"}}"#, self.select_response),
-                ))
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
+            if method == HttpMethod::Get {
+                self.get_calls.set(self.get_calls.get() + 1);
             }
-        }
 
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(FakeResponse::json(
+                        200,
+                        &format!(r#"{{"value":"{}"}}"#, self.select_response),
+                    )),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
+            }
         }
     }
 
-    impl HttpClient for BorrowingPostHttpClient {
+    impl BorrowHttpClient for BorrowingPostHttpClient {
         type Response = FakeResponse;
 
-        async fn get(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "GET is not used in this test".to_string(),
-            ))
-        }
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
+            if method == HttpMethod::Post {
+                self.post_calls.set(self.post_calls.get() + 1);
+            }
 
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            self.post_calls.set(self.post_calls.get() + 1);
-            Ok(FakeResponse::json(200, r#"{"results":[]}"#))
+            async move {
+                match method {
+                    HttpMethod::Get => Err(error::Error::Unknow(
+                        "GET is not used in this test".to_string(),
+                    )),
+                    HttpMethod::Post => Ok(FakeResponse::json(200, r#"{"results":[]}"#)),
+                }
+            }
         }
     }
 
-    impl HttpClient for BorrowingQueryGetHttpClient {
+    impl BorrowHttpClient for BorrowingWriteHttpClient {
         type Response = FakeResponse;
 
-        fn get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
-            self.get_calls.set(self.get_calls.get() + 1);
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
+            if method != HttpMethod::Post {
+                return futures::future::Either::Left(async {
+                    Err(error::Error::Unknow(
+                        "GET is not used in this test".to_string(),
+                    ))
+                });
+            }
 
-            async {
-                Ok(FakeResponse::json(
-                    200,
-                    r#"{"results":[{"statement_id":0,"series":null}]}"#,
-                ))
+            self.requests.set(self.requests.get() + 1);
+            let response = self.response.clone();
+            self.last_request.replace(Some(RecordedRequest {
+                method: "POST",
+                url: request.url().to_string(),
+                bearer_token: request.bearer_token().map(str::to_owned),
+                body: request.body().map(str::to_owned),
+            }));
+
+            futures::future::Either::Right(async move { Ok(response) })
+        }
+    }
+
+    impl BorrowHttpClient for BorrowingQueryGetHttpClient {
+        type Response = FakeResponse;
+
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
+            if method == HttpMethod::Get {
+                self.get_calls.set(self.get_calls.get() + 1);
+            }
+
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(FakeResponse::json(
+                        200,
+                        r#"{"results":[{"statement_id":0,"series":null}]}"#,
+                    )),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
             }
         }
+    }
 
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
+    impl BorrowHttpClient for SplitQueryHttpClient {
+        type Response = FakeResponse;
+
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
+            match method {
+                HttpMethod::Get => self.get_calls.set(self.get_calls.get() + 1),
+                HttpMethod::Post => self.post_calls.set(self.post_calls.get() + 1),
+            }
+
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(FakeResponse::json(
+                        200,
+                        &format!(
+                            r#"{{"results":[{{"statement_id":0,"value":"{}"}}]}}"#,
+                            self.response_body
+                        ),
+                    )),
+                    HttpMethod::Post => Ok(FakeResponse::json(200, r#"{"results":[]}"#)),
+                }
+            }
         }
     }
 
     impl HttpClient for SplitQueryHttpClient {
         type Response = FakeResponse;
 
-        fn get(
+        fn send(
             &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
-            self.get_calls.set(self.get_calls.get() + 1);
-
-            async {
-                Ok(FakeResponse::json(
-                    200,
-                    &format!(
-                        r#"{{"results":[{{"statement_id":0,"value":"{}"}}]}}"#,
-                        self.response_body
-                    ),
-                ))
-            }
-        }
-
-        fn post(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
-            self.post_calls.set(self.post_calls.get() + 1);
-            async { Ok(FakeResponse::json(200, r#"{"results":[]}"#)) }
-        }
-    }
-
-    impl QueryHttpClient for SplitQueryHttpClient {
-        fn send_get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
+            method: HttpMethod,
+            _request: HttpRequest<'static>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<>
+        {
             let response_body = self.response_body.clone();
 
             async move {
-                Ok(FakeResponse::json(
-                    200,
-                    &format!(
-                        r#"{{"results":[{{"statement_id":0,"value":"{}"}}]}}"#,
-                        response_body
-                    ),
-                ))
+                match method {
+                    HttpMethod::Get => Ok(FakeResponse::json(
+                        200,
+                        &format!(
+                            r#"{{"results":[{{"statement_id":0,"value":"{}"}}]}}"#,
+                            response_body
+                        ),
+                    )),
+                    HttpMethod::Post => Ok(FakeResponse::json(200, r#"{"results":[]}"#)),
+                }
             }
-        }
-
-        fn send_post(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
-            let response = FakeResponse::json(200, r#"{"results":[]}"#);
-            async move { Ok(response) }
         }
     }
 
-    impl HttpResponse for NonSendResponse {
+    impl BorrowHttpResponse for NonSendResponse {
         fn status(&self) -> u16 {
             self.status
         }
@@ -1732,31 +2104,31 @@ mod tests {
         }
     }
 
-    impl HttpClient for NonSendResponseHttpClient {
+    impl BorrowHttpClient for NonSendResponseHttpClient {
         type Response = NonSendResponse;
 
-        fn get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
             let body = self.response_body.clone();
 
             async move {
-                Ok(NonSendResponse {
-                    status: 200,
-                    body: Rc::new(body),
-                })
+                match method {
+                    HttpMethod::Get => Ok(NonSendResponse {
+                        status: 200,
+                        body: Rc::new(body),
+                    }),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
             }
-        }
-
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
         }
     }
 
-    impl HttpResponse for NonSendBodyFutureResponse {
+    impl BorrowHttpResponse for NonSendBodyFutureResponse {
         fn status(&self) -> u16 {
             self.status
         }
@@ -1787,31 +2159,31 @@ mod tests {
         }
     }
 
-    impl HttpClient for NonSendBodyFutureHttpClient {
+    impl BorrowHttpClient for NonSendBodyFutureHttpClient {
         type Response = NonSendBodyFutureResponse;
 
-        fn get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
             let body = self.response_body.clone();
 
             async move {
-                Ok(NonSendBodyFutureResponse {
-                    status: 200,
-                    body: Rc::new(body),
-                })
+                match method {
+                    HttpMethod::Get => Ok(NonSendBodyFutureResponse {
+                        status: 200,
+                        body: Rc::new(body),
+                    }),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
             }
-        }
-
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
         }
     }
 
-    impl HttpResponse for VersionHeaderResponse {
+    impl BorrowHttpResponse for VersionHeaderResponse {
         fn status(&self) -> u16 {
             self.status
         }
@@ -1848,13 +2220,14 @@ mod tests {
         }
     }
 
-    impl HttpClient for VersionHeaderHttpClient {
+    impl BorrowHttpClient for VersionHeaderHttpClient {
         type Response = VersionHeaderResponse;
 
-        fn get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
             let response = VersionHeaderResponse {
                 status: self.response.status,
                 version_header: match &self.response.version_header {
@@ -1864,17 +2237,18 @@ mod tests {
                 },
             };
 
-            async move { Ok(response) }
-        }
-
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(response),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
+            }
         }
     }
 
-    impl HttpResponse for ChunkedFakeResponse {
+    impl BorrowHttpResponse for ChunkedFakeResponse {
         fn status(&self) -> u16 {
             self.status
         }
@@ -1903,7 +2277,7 @@ mod tests {
         }
     }
 
-    impl ChunkedHttpResponse for ChunkedFakeResponse {
+    impl BorrowChunkedHttpResponse for ChunkedFakeResponse {
         type Stream = futures::stream::Iter<
             std::iter::Map<std::vec::IntoIter<Vec<u8>>, fn(Vec<u8>) -> Result<Bytes, error::Error>>,
         >;
@@ -1919,20 +2293,87 @@ mod tests {
         }
     }
 
-    impl QueryHttpResponse for ChunkedFakeResponse {
-        async fn json_send<T>(self) -> Result<T, error::Error>
+    impl HttpResponse for ChunkedFakeResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, _name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(None)
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Err(error::Error::Unknow(
+                "text is not used in this test".to_string(),
+            ))
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            panic!("chunked query should not eagerly buffer the whole response body")
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
         where
             T: DeserializeOwned + 'static,
         {
             Err(error::Error::Unknow(
-                "json_send is not used in this test".to_string(),
+                "json is not used in this test".to_string(),
             ))
         }
     }
 
-    impl QueryChunkedHttpResponse for ChunkedFakeResponse {
-        async fn into_chunk_stream_send(self) -> Result<Self::Stream, error::Error> {
-            self.into_chunk_stream().await
+    impl ChunkedHttpResponse for ChunkedFakeResponse {
+        type Stream = futures::stream::Iter<
+            std::iter::Map<std::vec::IntoIter<Vec<u8>>, fn(Vec<u8>) -> Result<Bytes, error::Error>>,
+        >;
+
+        async fn into_chunk_stream(self) -> Result<Self::Stream, error::Error> {
+            BorrowChunkedHttpResponse::into_chunk_stream(self).await
+        }
+    }
+
+    impl HttpResponse for OwnedOnlyChunkedResponse {
+        fn status(&self) -> u16 {
+            self.status
+        }
+
+        fn header(&self, _name: &str) -> Result<Option<&str>, error::Error> {
+            Ok(None)
+        }
+
+        async fn text(self) -> Result<String, error::Error> {
+            Err(error::Error::Unknow(
+                "text is not used in this test".to_string(),
+            ))
+        }
+
+        async fn bytes(self) -> Result<Bytes, error::Error> {
+            panic!("chunked query should not eagerly buffer the whole response body")
+        }
+
+        async fn json<T>(self) -> Result<T, error::Error>
+        where
+            T: DeserializeOwned + 'static,
+        {
+            Err(error::Error::Unknow(
+                "json is not used in this test".to_string(),
+            ))
+        }
+    }
+
+    impl ChunkedHttpResponse for OwnedOnlyChunkedResponse {
+        type Stream = futures::stream::Iter<
+            std::iter::Map<std::vec::IntoIter<Vec<u8>>, fn(Vec<u8>) -> Result<Bytes, error::Error>>,
+        >;
+
+        async fn into_chunk_stream(self) -> Result<Self::Stream, error::Error> {
+            fn into_bytes(segment: Vec<u8>) -> Result<Bytes, error::Error> {
+                Ok(Bytes::from(segment))
+            }
+
+            Ok(futures::stream::iter(self.segments.into_iter().map(
+                into_bytes as fn(Vec<u8>) -> Result<Bytes, error::Error>,
+            )))
         }
     }
 
@@ -1948,57 +2389,102 @@ mod tests {
         }
     }
 
+    impl OwnedOnlyHttpClient {
+        fn new(responses: Vec<OwnedOnlyResponse>) -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                responses: Arc::new(Mutex::new(responses.into_iter().rev().collect())),
+            }
+        }
+
+        fn take_requests(&self) -> Vec<RecordedRequest> {
+            self.requests.lock().unwrap().clone()
+        }
+
+        fn record_with(
+            requests: Arc<Mutex<Vec<RecordedRequest>>>,
+            responses: Arc<Mutex<Vec<OwnedOnlyResponse>>>,
+            method: &'static str,
+            request: HttpRequest<'static>,
+        ) -> Result<OwnedOnlyResponse, error::Error> {
+            requests.lock().unwrap().push(RecordedRequest {
+                method,
+                url: request.url().to_string(),
+                bearer_token: request.bearer_token().map(str::to_owned),
+                body: request.body().map(str::to_owned),
+            });
+
+            responses
+                .lock()
+                .unwrap()
+                .pop()
+                .ok_or_else(|| error::Error::Unknow("missing fake response".to_string()))
+        }
+    }
+
+    impl OwnedOnlyChunkedHttpClient {
+        fn new(response: OwnedOnlyChunkedResponse) -> Self {
+            Self { response }
+        }
+    }
+
+    impl BorrowHttpClient for ChunkedHttpClient {
+        type Response = ChunkedFakeResponse;
+
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
+            let response = self.response.clone();
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(response),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
+            }
+        }
+    }
+
     impl HttpClient for ChunkedHttpClient {
         type Response = ChunkedFakeResponse;
 
-        fn get(
+        fn send(
             &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+            method: HttpMethod,
+            _request: HttpRequest<'static>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<>
+        {
             let response = self.response.clone();
-            async move { Ok(response) }
-        }
-
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
-        }
-    }
-
-    impl QueryHttpClient for ChunkedHttpClient {
-        fn send_get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
-            let response = self.response.clone();
-            async move { Ok(response) }
-        }
-
-        fn send_post(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static {
             let error = error::Error::Unknow("POST is not used in this test".to_string());
-            async move { Err(error) }
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(response),
+                    HttpMethod::Post => Err(error),
+                }
+            }
         }
     }
 
-    impl HttpClient for BorrowingChunkedHttpClient {
+    impl BorrowHttpClient for BorrowingChunkedHttpClient {
         type Response = ChunkedFakeResponse;
 
-        fn get(
-            &self,
-            _request: HttpRequest,
-        ) -> impl Future<Output = Result<Self::Response, error::Error>> {
+        fn send<'a>(
+            &'a self,
+            method: HttpMethod,
+            _request: HttpRequest<'a>,
+        ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a> {
             let response = self.response.clone();
-            async move { Ok(response) }
-        }
-
-        async fn post(&self, _request: HttpRequest) -> Result<Self::Response, error::Error> {
-            Err(error::Error::Unknow(
-                "POST is not used in this test".to_string(),
-            ))
+            async move {
+                match method {
+                    HttpMethod::Get => Ok(response),
+                    HttpMethod::Post => Err(error::Error::Unknow(
+                        "POST is not used in this test".to_string(),
+                    )),
+                }
+            }
         }
     }
 
@@ -2038,7 +2524,7 @@ mod tests {
     }
 
     #[test]
-    fn ping_preserves_jwt_token() {
+    fn ping_borrow_preserves_jwt_token() {
         let http_client = RecordingHttpClient::new(vec![FakeResponse::empty(204)]);
         let client = Client::new_with_client(
             Url::parse("http://localhost:8086").unwrap(),
@@ -2047,7 +2533,7 @@ mod tests {
         )
         .set_jwt_token("jwt-token");
 
-        let ping = block_on(client.ping());
+        let ping = block_on(client.ping_borrow());
 
         assert!(ping);
 
@@ -2059,7 +2545,7 @@ mod tests {
     }
 
     #[test]
-    fn get_version_preserves_jwt_token() {
+    fn get_version_borrow_preserves_jwt_token() {
         let http_client = RecordingHttpClient::new(vec![FakeResponse {
             status: 204,
             headers: HashMap::from([("X-Influxdb-Version".to_string(), "1.8.10".to_string())]),
@@ -2072,7 +2558,7 @@ mod tests {
         )
         .set_jwt_token("jwt-token");
 
-        let version = block_on(client.get_version());
+        let version = block_on(client.get_version_borrow());
 
         assert_eq!(version.as_deref(), Some("1.8.10"));
 
@@ -2357,6 +2843,35 @@ mod tests {
     }
 
     #[test]
+    fn write_point_future_does_not_borrow_point_fields() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            RecordingHttpClient::new(vec![FakeResponse::empty(204)]),
+        );
+        let host = String::from("edge-a");
+        let point = Point::new("cpu")
+            .add_tag("host", host.as_str())
+            .add_field("value", 1)
+            .add_timestamp(42);
+        let future = client.write_point(point, Some(Precision::Seconds), None);
+
+        drop(host);
+
+        block_on(async {
+            tokio::spawn(future).await.unwrap().unwrap();
+        });
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "POST");
+        assert_eq!(
+            requests[0].body.as_deref(),
+            Some("cpu,host=edge-a value=1i 42\n")
+        );
+    }
+
+    #[test]
     fn query_can_be_spawned_with_cloneable_http_client() {
         let client = Client::new_with_client(
             Url::parse("http://localhost:8086").unwrap(),
@@ -2373,6 +2888,27 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
+            assert_eq!(result.unwrap()[0].statement_id, Some(0));
+        });
+    }
+
+    #[test]
+    fn owned_query_future_does_not_borrow_sql_input() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            RecordingHttpClient::new(vec![FakeResponse::json(
+                200,
+                r#"{"results":[{"statement_id":0,"series":null}]}"#,
+            )]),
+        );
+        let sql = String::from("select value from cpu");
+        let future = client.query(sql.as_str(), None);
+
+        drop(sql);
+
+        block_on(async {
+            let result = tokio::spawn(future).await.unwrap().unwrap();
             assert_eq!(result.unwrap()[0].statement_id, Some(0));
         });
     }
@@ -2398,13 +2934,14 @@ mod tests {
         );
 
         let response: NonSendQueryResult = block_on(async {
-            client
-                .send_request_borrow("select value from cpu", None, false)
-                .await
-                .unwrap()
-                .json::<NonSendQueryResult>()
-                .await
-                .unwrap()
+            BorrowHttpResponse::json(
+                client
+                    .send_request_borrow("select value from cpu", None, false)
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
         });
 
         assert_eq!(
@@ -2439,14 +2976,15 @@ mod tests {
             BorrowingPostHttpClient::new(),
         );
 
-        let query = block_on(async {
-            client
-                .send_request_borrow("create database metrics", None, false)
-                .await
-                .unwrap()
-                .json::<Query>()
-                .await
-                .unwrap()
+        let query: Query = block_on(async {
+            BorrowHttpResponse::json(
+                client
+                    .send_request_borrow("create database metrics", None, false)
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
         });
 
         assert_eq!(query.results, Some(Vec::new()));
@@ -2465,6 +3003,84 @@ mod tests {
 
         assert_eq!(result, Some(Vec::new()));
         assert_eq!(client.client.post_calls.get(), 1);
+    }
+
+    #[test]
+    fn write_point_borrow_supports_non_spawn_http_clients() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingWriteHttpClient::new(),
+        )
+        .set_jwt_token("jwt-token");
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        block_on(client.write_point_borrow(point, Some(Precision::Seconds), None)).unwrap();
+
+        assert_eq!(client.client.requests.get(), 1);
+        let request = client.client.last_request.borrow().clone().unwrap();
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.bearer_token.as_deref(), Some("jwt-token"));
+        assert_eq!(request.body.as_deref(), Some("cpu value=1i 42\n"));
+        assert!(request.url.contains("precision=s"));
+    }
+
+    #[test]
+    fn write_points_borrow_serializes_multiple_points() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingWriteHttpClient::new(),
+        );
+        let points = vec![
+            Point::new("cpu").add_field("value", 1).add_timestamp(42),
+            Point::new("mem").add_field("value", 2).add_timestamp(43),
+        ];
+
+        block_on(client.write_points_borrow(points, None, None)).unwrap();
+
+        assert_eq!(client.client.requests.get(), 1);
+        let request = client.client.last_request.borrow().clone().unwrap();
+        assert_eq!(
+            request.body.as_deref(),
+            Some("cpu value=1i 42\nmem value=2i 43\n")
+        );
+        assert!(request.url.contains("precision=n"));
+    }
+
+    #[test]
+    fn write_point_maps_database_missing_for_owned_transports() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            RecordingHttpClient::new(vec![FakeResponse::json(404, r#""missing db""#)]),
+        );
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        let err = block_on(client.write_point(point, Some(Precision::Seconds), None)).unwrap_err();
+
+        assert_eq!(
+            err,
+            error::Error::DataBaseDoesNotExist("missing db".to_string())
+        );
+    }
+
+    #[test]
+    fn write_point_borrow_maps_retention_policy_missing() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            BorrowingWriteHttpClient::with_response(FakeResponse::json(500, "rp missing")),
+        );
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        let err =
+            block_on(client.write_point_borrow(point, Some(Precision::Seconds), None)).unwrap_err();
+
+        assert_eq!(
+            err,
+            error::Error::RetentionPolicyDoesNotExist("rp missing".to_string())
+        );
     }
 
     #[test]
@@ -2605,7 +3221,7 @@ mod tests {
             }),
         );
 
-        let version = block_on(client.get_version());
+        let version = block_on(client.get_version_borrow());
 
         assert_eq!(version, None);
     }
@@ -2621,7 +3237,7 @@ mod tests {
             }),
         );
 
-        let version = block_on(client.get_version());
+        let version = block_on(client.get_version_borrow());
 
         assert_eq!(version.as_deref(), Some("Don't know"));
     }
@@ -2637,8 +3253,106 @@ mod tests {
             }),
         );
 
+        let version = block_on(client.get_version_borrow());
+
+        assert_eq!(version.as_deref(), Some("1.8.10"));
+    }
+
+    #[test]
+    fn owned_http_client_ping_uses_spawn_safe_transport() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            OwnedOnlyHttpClient::new(vec![OwnedOnlyResponse::empty(204)]),
+        )
+        .set_jwt_token("jwt-token");
+
+        let ping = block_on(client.ping());
+
+        assert!(ping);
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "GET");
+        assert_eq!(requests[0].bearer_token.as_deref(), Some("jwt-token"));
+        assert!(requests[0].url.contains("/ping"));
+    }
+
+    #[test]
+    fn owned_http_client_get_version_uses_spawn_safe_transport() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            OwnedOnlyHttpClient::new(vec![OwnedOnlyResponse::with_header(
+                204,
+                "X-Influxdb-Version",
+                "1.8.10",
+            )]),
+        );
+
         let version = block_on(client.get_version());
 
         assert_eq!(version.as_deref(), Some("1.8.10"));
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "GET");
+        assert!(requests[0].url.contains("/ping"));
+    }
+
+    #[test]
+    fn owned_chunked_query_only_needs_owned_chunked_traits() {
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            OwnedOnlyChunkedHttpClient::new(OwnedOnlyChunkedResponse {
+                status: 200,
+                segments: vec![
+                    br#"{"results":[{"statement_id":0"#.to_vec(),
+                    br#","series":null}]}"#.to_vec(),
+                ],
+            }),
+        );
+
+        block_on(async {
+            let mut query = client
+                .query_chunked("select value from cpu", None)
+                .await
+                .unwrap();
+            let first = query.next().await.unwrap().unwrap();
+
+            assert_eq!(first.results.unwrap()[0].statement_id, Some(0));
+            assert!(query.next().await.is_none());
+        });
+    }
+
+    #[test]
+    fn owned_http_client_can_back_query_and_write_apis_without_extra_traits() {
+        let http_client = OwnedOnlyHttpClient::new(vec![
+            OwnedOnlyResponse::json(200, r#"{"results":[{"statement_id":0,"series":null}]}"#),
+            OwnedOnlyResponse::empty(204),
+        ]);
+        let client = Client::new_with_client(
+            Url::parse("http://localhost:8086").unwrap(),
+            "metrics",
+            http_client,
+        );
+        let point = Point::new("cpu").add_field("value", 1).add_timestamp(42);
+
+        block_on(async {
+            let result = client.query("select value from cpu", None).await.unwrap();
+            assert_eq!(result.unwrap()[0].statement_id, Some(0));
+
+            client
+                .write_point(point, Some(Precision::Seconds), None)
+                .await
+                .unwrap();
+        });
+
+        let requests = client.client.take_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, "GET");
+        assert_eq!(requests[1].method, "POST");
+        assert_eq!(requests[1].body.as_deref(), Some("cpu value=1i 42\n"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,7 @@ impl From<io::Error> for Error {
     }
 }
 
+#[cfg(feature = "reqwest")]
 impl From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Self {
         Error::Communication(format!("{}", err))

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,160 @@
+use bytes::Bytes;
+use futures::Stream;
+use serde::de::DeserializeOwned;
+use std::future::Future;
+use url::Url;
+
+use crate::error;
+
+/// An abstract HTTP request used by [`HttpClient`] implementations.
+#[derive(Debug, Clone)]
+pub struct HttpRequest {
+    url: Url,
+    body: Option<String>,
+    bearer_token: Option<String>,
+}
+
+impl HttpRequest {
+    /// Create a new request for the provided URL.
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            body: None,
+            bearer_token: None,
+        }
+    }
+
+    /// Attach a request body.
+    pub fn with_body<T>(mut self, body: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.body = Some(body.into());
+        self
+    }
+
+    /// Attach a bearer token.
+    pub fn with_bearer_token<T>(mut self, token: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.bearer_token = Some(token.into());
+        self
+    }
+
+    /// View the request URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// View the request body.
+    pub fn body(&self) -> Option<&str> {
+        self.body.as_deref()
+    }
+
+    /// View the request bearer token.
+    pub fn bearer_token(&self) -> Option<&str> {
+        self.bearer_token.as_deref()
+    }
+
+    /// Decompose the request into its parts.
+    pub fn into_parts(self) -> (Url, Option<String>, Option<String>) {
+        (self.url, self.body, self.bearer_token)
+    }
+}
+
+/// An abstract HTTP response returned by [`HttpClient`].
+pub trait HttpResponse: Sized {
+    /// Return the HTTP status code.
+    fn status(&self) -> u16;
+
+    /// Return a response header by name.
+    fn header(&self, name: &str) -> Result<Option<&str>, error::Error>;
+
+    /// Read the response body as text.
+    fn text(self) -> impl Future<Output = Result<String, error::Error>>;
+
+    /// Read the response body as bytes.
+    fn bytes(self) -> impl Future<Output = Result<Bytes, error::Error>>;
+
+    /// Deserialize the response body as JSON.
+    fn json<T>(self) -> impl Future<Output = Result<T, error::Error>>
+    where
+        T: DeserializeOwned;
+}
+
+/// An HTTP response that can expose its body as an async byte stream for chunked queries.
+pub trait ChunkedHttpResponse: HttpResponse {
+    /// The async byte stream used to decode chunked query results.
+    type Stream: Stream<Item = Result<Bytes, error::Error>>;
+
+    /// Convert the response body into an async byte stream.
+    fn into_chunk_stream(
+        self,
+    ) -> impl Future<Output = Result<Self::Stream, error::Error>> + use<Self>;
+}
+
+/// An HTTP response that can expose its JSON body through a `Send + 'static` future.
+///
+/// This is required for owned query APIs, whose returned futures are spawnable.
+pub trait QueryHttpResponse: HttpResponse + Send + 'static {
+    /// Deserialize the response body as JSON through a `Send + 'static` future.
+    fn json_send<T>(self) -> impl Future<Output = Result<T, error::Error>> + Send + 'static
+    where
+        T: DeserializeOwned + 'static;
+}
+
+/// A chunked HTTP response that can expose its async byte stream through a `Send + 'static`
+/// future.
+pub trait QueryChunkedHttpResponse:
+    QueryHttpResponse + ChunkedHttpResponse<Stream: Send + 'static>
+{
+    /// Convert the response body into an async byte stream through a `Send + 'static` future.
+    fn into_chunk_stream_send(
+        self,
+    ) -> impl Future<Output = Result<Self::Stream, error::Error>> + Send + 'static;
+}
+
+/// An HTTP client that can service owned query APIs through spawnable futures.
+pub trait QueryHttpClient:
+    HttpClient<Response: QueryHttpResponse> + Clone + Send + 'static
+{
+    /// Send a GET request for owned query APIs.
+    fn send_get(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static;
+
+    /// Send a POST request for owned query APIs.
+    fn send_post(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static;
+}
+
+/// An HTTP client that can service write requests through spawnable futures.
+pub trait WriteHttpClient: HttpClient {
+    /// Send a POST request for write APIs, returning the status code and response body text.
+    fn post_send(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<(u16, String), error::Error>> + Send + 'static + use<Self>;
+}
+
+/// An abstract HTTP client that can service InfluxDB requests.
+pub trait HttpClient {
+    /// The response type produced by this client.
+    type Response: HttpResponse;
+
+    /// Send a GET request.
+    fn get(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'_, Self>;
+
+    /// Send a POST request.
+    fn post(
+        &self,
+        request: HttpRequest,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'_, Self>;
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,20 +1,20 @@
 use bytes::Bytes;
 use futures::Stream;
 use serde::de::DeserializeOwned;
-use std::future::Future;
+use std::{borrow::Cow, future::Future};
 use url::Url;
 
 use crate::error;
 
-/// An abstract HTTP request used by [`HttpClient`] implementations.
+/// An abstract HTTP request used by HTTP transport implementations.
 #[derive(Debug, Clone)]
-pub struct HttpRequest {
+pub struct HttpRequest<'a> {
     url: Url,
-    body: Option<String>,
-    bearer_token: Option<String>,
+    body: Option<Cow<'a, str>>,
+    bearer_token: Option<Cow<'a, str>>,
 }
 
-impl HttpRequest {
+impl<'a> HttpRequest<'a> {
     /// Create a new request for the provided URL.
     pub fn new(url: Url) -> Self {
         Self {
@@ -27,7 +27,7 @@ impl HttpRequest {
     /// Attach a request body.
     pub fn with_body<T>(mut self, body: T) -> Self
     where
-        T: Into<String>,
+        T: Into<Cow<'a, str>>,
     {
         self.body = Some(body.into());
         self
@@ -36,7 +36,7 @@ impl HttpRequest {
     /// Attach a bearer token.
     pub fn with_bearer_token<T>(mut self, token: T) -> Self
     where
-        T: Into<String>,
+        T: Into<Cow<'a, str>>,
     {
         self.bearer_token = Some(token.into());
         self
@@ -58,13 +58,33 @@ impl HttpRequest {
     }
 
     /// Decompose the request into its parts.
-    pub fn into_parts(self) -> (Url, Option<String>, Option<String>) {
+    pub fn into_parts(self) -> (Url, Option<Cow<'a, str>>, Option<Cow<'a, str>>) {
         (self.url, self.body, self.bearer_token)
+    }
+
+    /// Promote any borrowed request parts into owned storage.
+    pub fn into_owned(self) -> HttpRequest<'static> {
+        let (url, body, bearer_token) = self.into_parts();
+
+        HttpRequest {
+            url,
+            body: body.map(Cow::into_owned).map(Cow::Owned),
+            bearer_token: bearer_token.map(Cow::into_owned).map(Cow::Owned),
+        }
     }
 }
 
-/// An abstract HTTP response returned by [`HttpClient`].
-pub trait HttpResponse: Sized {
+/// The HTTP method used by spawn-safe request APIs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpMethod {
+    /// A GET request.
+    Get,
+    /// A POST request.
+    Post,
+}
+
+/// An abstract HTTP response returned by [`BorrowHttpClient`].
+pub trait BorrowHttpResponse: Sized {
     /// Return the HTTP status code.
     fn status(&self) -> u16;
 
@@ -84,7 +104,7 @@ pub trait HttpResponse: Sized {
 }
 
 /// An HTTP response that can expose its body as an async byte stream for chunked queries.
-pub trait ChunkedHttpResponse: HttpResponse {
+pub trait BorrowChunkedHttpResponse: BorrowHttpResponse {
     /// The async byte stream used to decode chunked query results.
     type Stream: Stream<Item = Result<Bytes, error::Error>>;
 
@@ -94,67 +114,98 @@ pub trait ChunkedHttpResponse: HttpResponse {
     ) -> impl Future<Output = Result<Self::Stream, error::Error>> + use<Self>;
 }
 
-/// An HTTP response that can expose its JSON body through a `Send + 'static` future.
+/// An HTTP response that can expose its body through `Send + 'static` futures.
 ///
-/// This is required for owned query APIs, whose returned futures are spawnable.
-pub trait QueryHttpResponse: HttpResponse + Send + 'static {
+/// This is required for spawn-safe query/write APIs, whose returned futures are spawnable.
+pub trait HttpResponse: Send + 'static {
+    /// Return the HTTP status code.
+    fn status(&self) -> u16;
+
+    /// Return a response header by name.
+    fn header(&self, name: &str) -> Result<Option<&str>, error::Error>;
+
+    /// Read the response body as text through a `Send + 'static` future.
+    fn text(
+        self,
+    ) -> impl Future<Output = Result<String, error::Error>> + Send + 'static + use<Self>;
+
+    /// Read the response body as bytes through a `Send + 'static` future.
+    fn bytes(
+        self,
+    ) -> impl Future<Output = Result<Bytes, error::Error>> + Send + 'static + use<Self>;
+
     /// Deserialize the response body as JSON through a `Send + 'static` future.
-    fn json_send<T>(self) -> impl Future<Output = Result<T, error::Error>> + Send + 'static
+    fn json<T>(
+        self,
+    ) -> impl Future<Output = Result<T, error::Error>> + Send + 'static + use<Self, T>
     where
         T: DeserializeOwned + 'static;
 }
 
 /// A chunked HTTP response that can expose its async byte stream through a `Send + 'static`
 /// future.
-pub trait QueryChunkedHttpResponse:
-    QueryHttpResponse + ChunkedHttpResponse<Stream: Send + 'static>
-{
+pub trait ChunkedHttpResponse: HttpResponse {
+    /// The async byte stream used to decode spawn-safe chunked query results.
+    type Stream: Stream<Item = Result<Bytes, error::Error>> + Send + 'static;
+
     /// Convert the response body into an async byte stream through a `Send + 'static` future.
-    fn into_chunk_stream_send(
+    fn into_chunk_stream(
         self,
-    ) -> impl Future<Output = Result<Self::Stream, error::Error>> + Send + 'static;
+    ) -> impl Future<Output = Result<Self::Stream, error::Error>> + Send + 'static + use<Self>;
 }
 
-/// An HTTP client that can service owned query APIs through spawnable futures.
-pub trait QueryHttpClient:
-    HttpClient<Response: QueryHttpResponse> + Clone + Send + 'static
-{
-    /// Send a GET request for owned query APIs.
-    fn send_get(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static;
-
-    /// Send a POST request for owned query APIs.
-    fn send_post(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static;
-}
-
-/// An HTTP client that can service write requests through spawnable futures.
-pub trait WriteHttpClient: HttpClient {
-    /// Send a POST request for write APIs, returning the status code and response body text.
-    fn post_send(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<(u16, String), error::Error>> + Send + 'static + use<Self>;
-}
-
-/// An abstract HTTP client that can service InfluxDB requests.
+/// An HTTP client that can service spawn-safe query/write APIs through spawnable futures.
 pub trait HttpClient {
-    /// The response type produced by this client.
+    /// The response type produced by this client for spawn-safe APIs.
     type Response: HttpResponse;
 
-    /// Send a GET request.
-    fn get(
+    /// Send a spawn-safe owned request.
+    fn send(
         &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'_, Self>;
+        method: HttpMethod,
+        request: HttpRequest<'static>,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + Send + 'static + use<Self>;
+}
 
-    /// Send a POST request.
-    fn post(
-        &self,
-        request: HttpRequest,
-    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'_, Self>;
+/// An HTTP client that can service borrowing InfluxDB request APIs.
+pub trait BorrowHttpClient {
+    /// The response type produced by this client.
+    type Response: BorrowHttpResponse;
+
+    /// Send a borrowing request.
+    fn send<'a>(
+        &'a self,
+        method: HttpMethod,
+        request: HttpRequest<'a>,
+    ) -> impl Future<Output = Result<Self::Response, error::Error>> + use<'a, Self>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HttpRequest;
+    use std::borrow::Cow;
+    use url::Url;
+
+    #[test]
+    fn http_request_preserves_borrowed_body_and_token() {
+        let request = HttpRequest::new(Url::parse("http://localhost:8086").unwrap())
+            .with_body("cpu value=1i")
+            .with_bearer_token("jwt-token");
+        let (_url, body, token) = request.into_parts();
+
+        assert!(matches!(body, Some(Cow::Borrowed("cpu value=1i"))));
+        assert!(matches!(token, Some(Cow::Borrowed("jwt-token"))));
+    }
+
+    #[test]
+    fn http_request_into_owned_promotes_borrowed_parts() {
+        let request = HttpRequest::new(Url::parse("http://localhost:8086").unwrap())
+            .with_body("cpu value=1i")
+            .with_bearer_token("jwt-token")
+            .into_owned();
+        let (_url, body, token) = request.into_parts();
+
+        assert!(matches!(body, Some(Cow::Owned(body)) if body == "cpu value=1i"));
+        assert!(matches!(token, Some(Cow::Owned(token)) if token == "jwt-token"));
+    }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,9 +1,14 @@
+use crate::{error::Error, serialization};
+use bytes::{Bytes, BytesMut};
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::HashMap,
-    iter::{FromIterator, Iterator},
+    iter::FromIterator,
+    pin::Pin,
     slice::Iter,
+    task::{Context, Poll},
 };
 
 /// Influxdb value, Please look at [this address](https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_reference/)
@@ -97,6 +102,15 @@ impl<'a, 'b> IntoIterator for &'a Points<'b> {
     }
 }
 
+impl<'a> IntoIterator for Points<'a> {
+    type Item = Point<'a>;
+    type IntoIter = std::vec::IntoIter<Point<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.point.into_iter()
+    }
+}
+
 impl<'a> FromIterator<Point<'a>> for Points<'a> {
     fn from_iter<T: IntoIterator<Item = Point<'a>>>(iter: T) -> Self {
         let mut points = Vec::new();
@@ -109,14 +123,6 @@ impl<'a> FromIterator<Point<'a>> for Points<'a> {
     }
 }
 
-impl<'a> Iterator for Points<'a> {
-    type Item = Point<'a>;
-
-    fn next(&mut self) -> Option<Point<'a>> {
-        self.point.pop()
-    }
-}
-
 /// Query data
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 pub struct Query {
@@ -126,14 +132,188 @@ pub struct Query {
     pub error: Option<String>,
 }
 
-/// Chunked Query data
-pub type ChunkedQuery<'de, T> = serde_json::StreamDeserializer<'de, T, Query>;
+impl Query {
+    pub(crate) fn error_message(&self) -> Option<&str> {
+        self.error.as_deref().or_else(|| {
+            self.results
+                .as_ref()
+                .and_then(|results| results.iter().find_map(|node| node.error.as_deref()))
+        })
+    }
+}
+
+pub(crate) fn query_syntax_error(query: &Query, fallback: &str) -> Error {
+    Error::SyntaxError(serialization::conversion(
+        query.error_message().unwrap_or(fallback),
+    ))
+}
+
+pub(crate) fn ensure_query_success(query: Query) -> Result<Query, Error> {
+    if let Some(err) = query.error_message() {
+        Err(Error::SyntaxError(serialization::conversion(err)))
+    } else {
+        Ok(query)
+    }
+}
+
+/// Chunked query stream that yields parsed query documents and surfaces query errors.
+pub struct ChunkedQuery<S> {
+    inner: S,
+    buffer: BytesMut,
+    scanner: JsonObjectScanner,
+    stream_finished: bool,
+    terminated: bool,
+}
+
+impl<S> ChunkedQuery<S> {
+    pub(crate) fn new(inner: S) -> Self {
+        Self {
+            inner,
+            buffer: BytesMut::new(),
+            scanner: JsonObjectScanner::default(),
+            stream_finished: false,
+            terminated: false,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct JsonObjectScanner {
+    offset: usize,
+    depth: usize,
+    in_string: bool,
+    escaped: bool,
+    started: bool,
+}
+
+impl JsonObjectScanner {
+    fn next_document_end(&mut self, bytes: &[u8]) -> Option<usize> {
+        while self.offset < bytes.len() {
+            let byte = bytes[self.offset];
+            self.offset += 1;
+
+            if self.in_string {
+                if self.escaped {
+                    self.escaped = false;
+                } else if byte == b'\\' {
+                    self.escaped = true;
+                } else if byte == b'"' {
+                    self.in_string = false;
+                }
+
+                continue;
+            }
+
+            match byte {
+                b'{' => {
+                    self.started = true;
+                    self.depth += 1;
+                }
+                b'}' if self.started && self.depth > 0 => {
+                    self.depth -= 1;
+                    if self.depth == 0 {
+                        let end = self.offset;
+                        self.reset();
+                        return Some(end);
+                    }
+                }
+                b'"' if self.started => self.in_string = true,
+                b if b.is_ascii_whitespace() && !self.started => {}
+                _ if !self.started => self.started = true,
+                _ => {}
+            }
+        }
+
+        None
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+impl<S> Stream for ChunkedQuery<S>
+where
+    S: Stream<Item = Result<Bytes, Error>>,
+{
+    type Item = Result<Query, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            {
+                let this = unsafe { self.as_mut().get_unchecked_mut() };
+
+                if this.terminated {
+                    return Poll::Ready(None);
+                }
+
+                if !this.buffer.is_empty() {
+                    if let Some(end) = this.scanner.next_document_end(&this.buffer) {
+                        let document = this.buffer.split_to(end).freeze();
+                        match serde_json::from_slice::<Query>(&document) {
+                            Ok(query) => return Poll::Ready(Some(ensure_query_success(query))),
+                            Err(err) => {
+                                this.terminated = true;
+                                return Poll::Ready(Some(Err(Error::Communication(
+                                    err.to_string(),
+                                ))));
+                            }
+                        }
+                    }
+
+                    if this.stream_finished {
+                        if this.buffer.iter().all(u8::is_ascii_whitespace) {
+                            this.terminated = true;
+                            return Poll::Ready(None);
+                        }
+
+                        match serde_json::from_slice::<Query>(&this.buffer) {
+                            Ok(query) => {
+                                this.buffer.clear();
+                                this.scanner.reset();
+                                return Poll::Ready(Some(ensure_query_success(query)));
+                            }
+                            Err(err) => {
+                                this.terminated = true;
+                                return Poll::Ready(Some(Err(Error::Communication(
+                                    err.to_string(),
+                                ))));
+                            }
+                        }
+                    }
+                } else if this.stream_finished {
+                    this.terminated = true;
+                    return Poll::Ready(None);
+                }
+            }
+
+            match unsafe { self.as_mut().map_unchecked_mut(|this| &mut this.inner) }.poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    let this = unsafe { self.as_mut().get_unchecked_mut() };
+                    this.buffer.extend_from_slice(&bytes);
+                }
+                Poll::Ready(Some(Err(err))) => {
+                    let this = unsafe { self.as_mut().get_unchecked_mut() };
+                    this.terminated = true;
+                    return Poll::Ready(Some(Err(err)));
+                }
+                Poll::Ready(None) => {
+                    let this = unsafe { self.as_mut().get_unchecked_mut() };
+                    this.stream_finished = true;
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
 
 /// Query data node
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 pub struct Node {
     /// id
     pub statement_id: Option<u64>,
+    /// fail message
+    pub error: Option<String>,
     /// series
     pub series: Option<Vec<Series>>,
 }
@@ -197,9 +377,7 @@ macro_rules! points {
 /// Create Point by macro
 #[macro_export]
 macro_rules! point {
-    ($x:expr) => {{
-        Point::new($x)
-    }};
+    ($x:expr) => {{ Point::new($x) }};
     ($x:expr, $y:expr, $z:expr) => {{
         Point {
             measurement: String::from($x),
@@ -269,5 +447,49 @@ impl<'a> From<f32> for Value<'a> {
 impl<'a> From<bool> for Value<'a> {
     fn from(v: bool) -> Self {
         Self::Boolean(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use futures::{StreamExt, executor::block_on, stream};
+
+    #[test]
+    fn json_object_scanner_tracks_boundary_across_chunks() {
+        let mut scanner = JsonObjectScanner::default();
+        let mut buffer = br#"{"results":[{"statement_id":0"#.to_vec();
+
+        assert_eq!(scanner.next_document_end(&buffer), None);
+
+        buffer.extend_from_slice(br#","series":null}]}"#);
+        assert_eq!(scanner.next_document_end(&buffer), Some(buffer.len()));
+    }
+
+    #[test]
+    fn json_object_scanner_ignores_braces_inside_strings() {
+        let mut scanner = JsonObjectScanner::default();
+        let buffer =
+            br#"{"results":[{"statement_id":0,"error":"brace } and quote \" stay inside"}]}"#;
+
+        assert_eq!(scanner.next_document_end(buffer), Some(buffer.len()));
+    }
+
+    #[test]
+    fn chunked_query_parses_back_to_back_documents_without_newline_delimiters() {
+        let stream = stream::iter(vec![Ok(Bytes::from_static(
+            br#"{"results":[{"statement_id":0,"series":null}]}{"results":[{"statement_id":1,"series":null}]}"#,
+        ))]);
+        let mut query = ChunkedQuery::new(stream);
+
+        block_on(async {
+            let first = query.next().await.unwrap().unwrap();
+            let second = query.next().await.unwrap().unwrap();
+
+            assert_eq!(first.results.unwrap()[0].statement_id, Some(0));
+            assert_eq!(second.results.unwrap()[0].statement_id, Some(1));
+            assert!(query.next().await.is_none());
+        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! let points = points!(point1, point);
 //!
 //! tokio::runtime::Runtime::new().unwrap().block_on(async move {
-//!     // if Precision is None, the default is second
+//!     // if Precision is None, the default is nanosecond
 //!     // Multiple write
 //!     client.write_points(points, Some(Precision::Seconds), None).await.unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,19 @@
 //!
 //! `Client` defaults to `reqwest::Client` when the default `reqwest` feature is enabled,
 //! but it is generic over the HTTP implementation.
-//! Implement [`HttpClient`] and [`HttpResponse`] to plug in a custom transport with
-//! [`Client::new_with_client`]. Borrowing query APIs such as [`Client::query_borrow`] and
-//! [`Client::query_chunked_borrow`] only require those base traits. Owned query APIs such as
-//! [`Client::query`], [`Client::query_chunked`], and the query-backed management commands require
-//! [`QueryHttpClient`] and [`QueryHttpResponse`]. Owned chunked queries also require
-//! [`QueryChunkedHttpResponse`]. Custom transports that need write APIs should additionally
-//! implement [`WriteHttpClient`] for their client type.
+//! Implement the transport traits for the APIs you want to support, then plug the transport into
+//! [`Client::new_with_client`]. Borrowing APIs such as [`Client::ping_borrow`],
+//! [`Client::get_version_borrow`], [`Client::query_borrow`], [`Client::query_chunked_borrow`],
+//! [`Client::write_point_borrow`], and [`Client::write_points_borrow`] require [`BorrowHttpClient`]
+//! and [`BorrowHttpResponse`]. Borrowed chunked queries also require
+//! [`BorrowChunkedHttpResponse`]. Spawn-safe APIs such as [`Client::ping`],
+//! [`Client::get_version`], [`Client::query`], [`Client::query_chunked`],
+//! [`Client::write_point`], and [`Client::write_points`] plus the query-backed management
+//! commands require [`HttpClient`] and [`HttpResponse`]. Spawn-safe chunked queries also require
+//! [`ChunkedHttpResponse`]. You can implement borrowed-only, spawn-safe-only, or both modes on
+//! the same transport type.
+//! Borrowing APIs pass borrowed [`HttpRequest`] data through the borrow transport traits, while
+//! the spawnable query/write APIs pass owned `HttpRequest<'static>` values.
 //! Chunked responses now yield an async byte stream instead of a blocking reader.
 //! Disable default features if you want to avoid compiling `reqwest` and provide your own
 //! HTTP client.
@@ -61,6 +67,12 @@
 //! `query_chunked` is also an incompatible change now: it returns an async [`futures::Stream`]
 //! instead of a synchronous iterator. Import `futures::StreamExt` to consume it with
 //! `.next().await`.
+//!
+//! ```rust,compile_fail
+//! use influx_db_client::{
+//!     QueryChunkedHttpResponse, QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+//! };
+//! ```
 //!
 //! ### udp
 //!
@@ -92,8 +104,8 @@ pub(crate) mod serialization;
 pub use client::{Client, UdpClient};
 pub use error::Error;
 pub use http::{
-    ChunkedHttpResponse, HttpClient, HttpRequest, HttpResponse, QueryChunkedHttpResponse,
-    QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+    BorrowChunkedHttpResponse, BorrowHttpClient, BorrowHttpResponse, ChunkedHttpResponse,
+    HttpClient, HttpMethod, HttpRequest, HttpResponse,
 };
 pub use keys::{ChunkedQuery, Node, Point, Points, Precision, Query, Series, Value};
 pub use url::Url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,48 +6,71 @@
 //!
 //! ### http
 //!
-//! ```Rust
-//! use influx_db_client::{Client, Point, Points, Value, Precision};
+//! ```rust,no_run
+//! # #[cfg(feature = "reqwest")] {
+//! use influx_db_client::{Client, Point, Points, Precision, point, points};
 //!
 //! // default with "http://127.0.0.1:8086", db with "test"
 //! let client = Client::default().set_authentication("root", "root");
 //!
-//! let mut point = point!("test1");
-//! let point = point
-//!       .add_field("foo", Value::String("bar".to_string()))
-//!       .add_field("integer", Value::Integer(11))
-//!       .add_field("float", Value::Float(22.3))
-//!       .add_field("'boolean'", Value::Boolean(false));
+//! let point = point!("test1")
+//!       .add_field("foo", "bar")
+//!       .add_field("integer", 11)
+//!       .add_field("float", 22.3)
+//!       .add_field("'boolean'", false);
 //!
 //! let point1 = Point::new("test1")
-//!       .add_tag("tags", Value::String(String::from("\\\"fda")))
-//!       .add_tag("number", Value::Integer(12))
-//!       .add_tag("float", Value::Float(12.6))
-//!       .add_field("fd", Value::String("'3'".to_string()))
-//!       .add_field("quto", Value::String("\\\"fda".to_string()))
-//!       .add_field("quto1", Value::String("\"fda".to_string()));
+//!       .add_tag("tags", "\\\"fda")
+//!       .add_tag("number", 12)
+//!       .add_tag("float", 12.6)
+//!       .add_field("fd", "'3'")
+//!       .add_field("quto", "\\\"fda")
+//!       .add_field("quto1", "\"fda");
 //!
 //! let points = points!(point1, point);
 //!
-//! // if Precision is None, the default is second
-//! // Multiple write
-//! client.write_points(points, Some(Precision::Seconds), None).unwrap();
+//! tokio::runtime::Runtime::new().unwrap().block_on(async move {
+//!     // if Precision is None, the default is second
+//!     // Multiple write
+//!     client.write_points(points, Some(Precision::Seconds), None).await.unwrap();
 //!
-//! // query, it's type is Option<Vec<Node>>
-//! let res = client.query("select * from test1", None).unwrap();
-//! println!("{:?}", res.unwrap()[0].series)
+//!     // query, it's type is Option<Vec<Node>>
+//!     let res = client.query("select * from test1", None).await.unwrap();
+//!     println!("{:?}", res.unwrap()[0].series);
+//! });
+//! # }
 //! ```
+//!
+//! `Client` defaults to `reqwest::Client` when the default `reqwest` feature is enabled,
+//! but it is generic over the HTTP implementation.
+//! Implement [`HttpClient`] and [`HttpResponse`] to plug in a custom transport with
+//! [`Client::new_with_client`]. Borrowing query APIs such as [`Client::query_borrow`] and
+//! [`Client::query_chunked_borrow`] only require those base traits. Owned query APIs such as
+//! [`Client::query`], [`Client::query_chunked`], and the query-backed management commands require
+//! [`QueryHttpClient`] and [`QueryHttpResponse`]. Owned chunked queries also require
+//! [`QueryChunkedHttpResponse`]. Custom transports that need write APIs should additionally
+//! implement [`WriteHttpClient`] for their client type.
+//! Chunked responses now yield an async byte stream instead of a blocking reader.
+//! Disable default features if you want to avoid compiling `reqwest` and provide your own
+//! HTTP client.
+//! The default `reqwest/default-tls` path currently resolves to rustls.
+//! This is an incompatible feature-name update: the previous `rustls-tls*` feature names were
+//! removed. Disable default features and enable `native-tls` to use reqwest's native-tls backend.
+//! On Linux that typically means OpenSSL; on macOS and Windows it uses the platform TLS stack.
+//!
+//! `query_chunked` is also an incompatible change now: it returns an async [`futures::Stream`]
+//! instead of a synchronous iterator. Import `futures::StreamExt` to consume it with
+//! `.next().await`.
 //!
 //! ### udp
 //!
-//! ```Rust
-//! use influx_db_client::{UdpClient, Point, Value};
+//! ```rust,no_run
+//! use influx_db_client::{Point, UdpClient, point};
 //!
 //! let mut udp = UdpClient::new("127.0.0.1:8089".parse().unwrap());
 //! udp.add_host("127.0.0.1:8090".parse().unwrap());
 //!
-//! let mut point = point!("test");
-//! point.add_field("foo", Value::String(String::from("bar")));
+//! let point = point!("test").add_field("foo", "bar");
 //!
 //! udp.write_point(point).unwrap();
 //! ```
@@ -59,6 +82,8 @@
 pub mod client;
 /// Error module
 pub mod error;
+/// HTTP transport abstraction types and traits.
+pub mod http;
 /// Points and Query Data Deserialize
 pub mod keys;
 /// Serialization module
@@ -66,6 +91,12 @@ pub(crate) mod serialization;
 
 pub use client::{Client, UdpClient};
 pub use error::Error;
+pub use http::{
+    ChunkedHttpResponse, HttpClient, HttpRequest, HttpResponse, QueryChunkedHttpResponse,
+    QueryHttpClient, QueryHttpResponse, WriteHttpClient,
+};
 pub use keys::{ChunkedQuery, Node, Point, Points, Precision, Query, Series, Value};
+pub use url::Url;
 
+#[cfg(feature = "reqwest")]
 pub use reqwest;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,5 +1,5 @@
 use crate::{Point, Value};
-use std::borrow::Borrow;
+use std::{borrow::Borrow, fmt::Write as _};
 
 /// Resolve the points to line protocol format
 pub(crate) fn line_serialization<'a>(
@@ -9,24 +9,18 @@ pub(crate) fn line_serialization<'a>(
 
     for point in points {
         let point: &Point = point.borrow();
-        line.push_str(&escape_measurement(&point.measurement));
+        push_escaped_measurement(&mut line, &point.measurement);
 
         for (tag, value) in &point.tags {
             line.push(',');
-            line.push_str(&escape_keys_and_tags(tag));
+            push_escaped_keys_and_tags(&mut line, tag);
             line.push('=');
 
             match value {
-                Value::String(s) => line.push_str(&escape_keys_and_tags(s)),
-                Value::Float(f) => line.push_str(f.to_string().as_str()),
-                Value::Integer(i) => line.push_str(i.to_string().as_str()),
-                Value::Boolean(b) => line.push_str({
-                    if *b {
-                        "true"
-                    } else {
-                        "false"
-                    }
-                }),
+                Value::String(s) => push_escaped_keys_and_tags(&mut line, s),
+                Value::Float(f) => push_display(&mut line, f),
+                Value::Integer(i) => push_display(&mut line, i),
+                Value::Boolean(b) => line.push_str(bool_str(*b)),
             }
         }
 
@@ -41,28 +35,23 @@ pub(crate) fn line_serialization<'a>(
                     ','
                 }
             });
-            line.push_str(&escape_keys_and_tags(field));
+            push_escaped_keys_and_tags(&mut line, field);
             line.push('=');
 
             match value {
-                Value::String(s) => {
-                    line.push_str(&escape_string_field_value(&s.replace("\\\"", "\\\\\"")))
+                Value::String(s) => push_escaped_string_field_value(&mut line, s),
+                Value::Float(f) => push_display(&mut line, f),
+                Value::Integer(i) => {
+                    push_display(&mut line, i);
+                    line.push('i')
                 }
-                Value::Float(f) => line.push_str(&f.to_string()),
-                Value::Integer(i) => line.push_str(&format!("{i}i")),
-                Value::Boolean(b) => line.push_str({
-                    if *b {
-                        "true"
-                    } else {
-                        "false"
-                    }
-                }),
+                Value::Boolean(b) => line.push_str(bool_str(*b)),
             }
         }
 
         if let Some(t) = point.timestamp {
             line.push(' ');
-            line.push_str(&t.to_string());
+            push_display(&mut line, t);
         }
 
         line.push('\n')
@@ -73,53 +62,133 @@ pub(crate) fn line_serialization<'a>(
 
 #[inline]
 pub(crate) fn quote_ident(value: &str) -> String {
-    format!(
-        "\"{}\"",
-        value
-            .replace('\\', "\\\\")
-            .replace('\"', "\\\"")
-            .replace('\n', "\\n")
-    )
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' | '"' => {
+                quoted.push('\\');
+                quoted.push(ch);
+            }
+            '\n' => quoted.push_str("\\n"),
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
 }
 
 #[inline]
 pub(crate) fn quote_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('\'');
+    for ch in value.chars() {
+        match ch {
+            '\\' | '\'' => {
+                quoted.push('\\');
+                quoted.push(ch);
+            }
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 #[inline]
 pub(crate) fn conversion(value: &str) -> String {
-    value
-        .replace('\'', "")
-        .replace('\"', "")
-        .replace('\\', "")
-        .trim()
-        .to_string()
+    let mut converted = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if !matches!(ch, '\'' | '"' | '\\') {
+            converted.push(ch);
+        }
+    }
+
+    let trimmed = converted.trim();
+    if trimmed.len() == converted.len() {
+        converted
+    } else {
+        trimmed.to_string()
+    }
 }
 
 #[inline]
-fn escape_keys_and_tags(value: impl AsRef<str>) -> String {
-    value
-        .as_ref()
-        .replace(',', "\\,")
-        .replace('=', "\\=")
-        .replace(' ', "\\ ")
+fn bool_str(value: bool) -> &'static str {
+    if value { "true" } else { "false" }
 }
 
 #[inline]
-fn escape_measurement(value: &str) -> String {
-    value.replace(',', "\\,").replace(' ', "\\ ")
+fn push_display(buffer: &mut String, value: impl std::fmt::Display) {
+    write!(buffer, "{value}").expect("writing to a string cannot fail");
 }
 
 #[inline]
-fn escape_string_field_value(value: &str) -> String {
-    format!("\"{}\"", value.replace('\"', "\\\""))
+fn push_escaped_keys_and_tags(buffer: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            ',' | '=' | ' ' => {
+                buffer.push('\\');
+                buffer.push(ch);
+            }
+            _ => buffer.push(ch),
+        }
+    }
+}
+
+#[inline]
+fn push_escaped_measurement(buffer: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            ',' | ' ' => {
+                buffer.push('\\');
+                buffer.push(ch);
+            }
+            _ => buffer.push(ch),
+        }
+    }
+}
+
+#[inline]
+fn push_escaped_string_field_value(buffer: &mut String, value: &str) {
+    buffer.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' | '"' => {
+                buffer.push('\\');
+                buffer.push(ch);
+            }
+            _ => buffer.push(ch),
+        }
+    }
+    buffer.push('"');
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::{Point, Points};
+
+    #[inline]
+    fn escape_keys_and_tags(value: impl AsRef<str>) -> String {
+        let value = value.as_ref();
+        let mut escaped = String::with_capacity(value.len());
+        push_escaped_keys_and_tags(&mut escaped, value);
+        escaped
+    }
+
+    #[inline]
+    fn escape_measurement(value: &str) -> String {
+        let mut escaped = String::with_capacity(value.len());
+        push_escaped_measurement(&mut escaped, value);
+        escaped
+    }
+
+    #[inline]
+    fn escape_string_field_value(value: &str) -> String {
+        let mut escaped = String::with_capacity(value.len() + 2);
+        push_escaped_string_field_value(&mut escaped, value);
+        escaped
+    }
 
     #[test]
     fn line_serialization_test() {
@@ -150,6 +219,26 @@ mod test {
     #[test]
     fn escape_string_field_value_test() {
         assert_eq!(escape_string_field_value("\"foo"), "\"\\\"foo\"")
+    }
+
+    #[test]
+    fn escape_string_field_value_escapes_backslashes() {
+        let point = Point::new("test").add_field("path", r"C:\tmp");
+        let points = Points::new(point);
+
+        assert_eq!(line_serialization(&points), "test path=\"C:\\\\tmp\"\n");
+    }
+
+    #[test]
+    fn line_serialization_preserves_point_order_when_consuming_points() {
+        let first = Point::new("first").add_field("value", 1);
+        let second = Point::new("second").add_field("value", 2);
+        let points = Points::create_new(vec![first, second]);
+
+        assert_eq!(
+            line_serialization(points),
+            "first value=1i\nsecond value=2i\n"
+        );
     }
 
     #[test]

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -123,6 +123,9 @@ fn use_udp() {
         udp.add_host("127.0.0.1:8090".parse().unwrap());
         let mut client = Client::default().set_authentication("root", "root");
 
+        client.create_database("udp").await.unwrap();
+        client.create_database("telegraf").await.unwrap();
+
         let point = point!("test").add_field("foo", "bar");
 
         udp.write_point(point).unwrap();
@@ -145,13 +148,37 @@ fn use_https() {
 
     use tempdir::TempDir;
 
+    fn run_openssl(args: &[&str]) {
+        let output = Command::new("openssl")
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "openssl {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     // https://docs.influxdata.com/influxdb/v1.5/administration/https_setup/#setup-https-with-a-self-signed-certificate
     let dir = TempDir::new("test_use_https").unwrap();
     let dir_path: String = dir.path().to_str().unwrap().to_owned();
+    let ca_key_path: String = dir.path().join("test-ca.key").to_str().unwrap().to_owned();
+    let ca_cert_path: String = dir.path().join("test-ca.cert").to_str().unwrap().to_owned();
     let tls_key_filename = "influxdb-selfsigned.key";
     let tls_key_path: String = dir
         .path()
         .join(tls_key_filename)
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let tls_csr_path: String = dir
+        .path()
+        .join("influxdb-selfsigned.csr")
         .to_str()
         .unwrap()
         .to_owned();
@@ -162,27 +189,81 @@ fn use_https() {
         .to_str()
         .unwrap()
         .to_owned();
-    let output = Command::new("openssl")
-        .args([
-            "req",
-            "-x509",
-            "-nodes",
-            "-newkey",
-            "rsa:2048",
-            "-days",
-            "10",
-            "-subj",
-            "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=localhost",
-            "-keyout",
-            tls_key_path.as_str(),
-            "-out",
-            tls_cert_path.as_str(),
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
+    let tls_ext_path: String = dir
+        .path()
+        .join("influxdb-selfsigned.ext")
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    run_openssl(&[
+        "req",
+        "-x509",
+        "-nodes",
+        "-newkey",
+        "rsa:2048",
+        "-days",
+        "10",
+        "-sha256",
+        "-subj",
+        "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=InfluxDB Test CA",
+        "-addext",
+        "basicConstraints=critical,CA:TRUE",
+        "-addext",
+        "keyUsage=critical,keyCertSign,cRLSign",
+        "-addext",
+        "subjectKeyIdentifier=hash",
+        "-keyout",
+        ca_key_path.as_str(),
+        "-out",
+        ca_cert_path.as_str(),
+    ]);
+
+    run_openssl(&[
+        "req",
+        "-nodes",
+        "-newkey",
+        "rsa:2048",
+        "-subj",
+        "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=localhost",
+        "-keyout",
+        tls_key_path.as_str(),
+        "-out",
+        tls_csr_path.as_str(),
+    ]);
+
+    let mut tls_ext_file = fs::File::create(tls_ext_path.as_str()).unwrap();
+    tls_ext_file
+        .write_all(
+            br#"basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+"#,
+        )
         .unwrap();
-    println!("openssl output: {:?}", output);
+    drop(tls_ext_file);
+
+    run_openssl(&[
+        "x509",
+        "-req",
+        "-in",
+        tls_csr_path.as_str(),
+        "-CA",
+        ca_cert_path.as_str(),
+        "-CAkey",
+        ca_key_path.as_str(),
+        "-CAcreateserial",
+        "-days",
+        "10",
+        "-sha256",
+        "-extfile",
+        tls_ext_path.as_str(),
+        "-out",
+        tls_cert_path.as_str(),
+    ]);
 
     let influxdb_config_path: String = dir
         .path()
@@ -217,7 +298,17 @@ bind-address = "127.0.0.1:{rpc_port}"
     f.sync_all().unwrap();
     drop(f);
 
-    for path in [&tls_key_path, &tls_cert_path, &influxdb_config_path].iter() {
+    for path in [
+        &ca_key_path,
+        &ca_cert_path,
+        &tls_key_path,
+        &tls_csr_path,
+        &tls_cert_path,
+        &tls_ext_path,
+        &influxdb_config_path,
+    ]
+    .iter()
+    {
         assert!(fs::metadata(path).is_ok());
     }
 
@@ -232,7 +323,7 @@ bind-address = "127.0.0.1:{rpc_port}"
         thread::sleep(Duration::from_millis(500));
     }
 
-    let mut ca_cert_file = File::open(tls_cert_path.as_str()).unwrap();
+    let mut ca_cert_file = File::open(ca_cert_path.as_str()).unwrap();
     let mut ca_cert_buffer = Vec::new();
     ca_cert_file.read_to_end(&mut ca_cert_buffer).unwrap();
 
@@ -243,7 +334,31 @@ bind-address = "127.0.0.1:{rpc_port}"
         .build()
         .unwrap();
 
-    let host = format!("https://localhost:{}", http_port);
+    block_on(async {
+        let ping_url = format!("https://127.0.0.1:{http_port}/ping");
+        let mut last_error = None;
+
+        for _ in 0..20 {
+            match http_client.get(&ping_url).send().await {
+                Ok(response) if response.status() == 204 => return,
+                Ok(response) => {
+                    last_error = Some(format!("unexpected /ping status {}", response.status()));
+                }
+                Err(err) => {
+                    last_error = Some(format!("{err:?}"));
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        panic!(
+            "https influxdb server did not become ready: {}",
+            last_error.unwrap_or_else(|| "unknown error".to_string())
+        );
+    });
+
+    let host = format!("https://127.0.0.1:{}", http_port);
     let client = Client::new_with_client(
         Url::parse(host.as_str()).unwrap(),
         "test_use_https",

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -1,4 +1,6 @@
-use influx_db_client::{point, points, reqwest::Url, Client, Point, Points, Precision, UdpClient};
+#![cfg(feature = "reqwest")]
+
+use influx_db_client::{Client, Point, Points, Precision, UdpClient, Url, point, points, reqwest};
 use std::fs::File;
 use std::io::Read;
 use std::thread::sleep;
@@ -161,7 +163,7 @@ fn use_https() {
         .unwrap()
         .to_owned();
     let output = Command::new("openssl")
-        .args(&[
+        .args([
             "req",
             "-x509",
             "-nodes",
@@ -262,4 +264,5 @@ bind-address = "127.0.0.1:{rpc_port}"
     });
 
     influxdb_server.kill().unwrap();
+    influxdb_server.wait().unwrap();
 }


### PR DESCRIPTION
This is a major change:

1. Generic client implementation, allowing users to choose their own client and runtime dependencies. `reqwest` is implemented by default, but can be disabled using a feature. Here's an implementation example.
2. Optimized line protocol implementation, reducing memory allocation frequency.
3. Separated implementations of the `Send` and non-`Send` interfaces. Users can implement them as needed; not all implementations are required for use.
4. Currently, chunk query has been truly implemented, returning a Stream type for segmented parsing.

If no one objects, I will merge this PR and release version 0.7 in two days. close #38 